### PR TITLE
Update Comments.tmPreferences

### DIFF
--- a/preferences/Comments.tmPreferences
+++ b/preferences/Comments.tmPreferences
@@ -5,7 +5,7 @@
   <key>name</key>
   <string>Comments</string>
   <key>scope</key>
-  <string>source.toit</string>
+  <string>source.pkl</string>
   <key>settings</key>
   <dict>
     <key>shellVariables</key>


### PR DESCRIPTION
it was pointing at .toit source instead of pkl

Currently the auto toggle_comments command in sublime is not working for this syntax.