### PR TITLE
Adds support to some more base elements in the language

### DIFF
--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -97,7 +97,11 @@ the species will be remembered.
 """
 
 bird = "Dodo"
-str = #" \\\\\ \#n \#u{12AF} \#(bird) """"" "#"
+str = #" \\\\\ \#n \#u{12AF} \#(bird) """"" "#
+str2 = ##" """"\\\\\ \# \##(bird) "##
+mstrig #"""
+  hello there \#(general_kenobi)
+"""#
 
 strLength = "dodo".length 
 reversedStr = "dodo".reverse() 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -135,7 +135,7 @@ res8 = 5.min % 3
 res9 = 5.min ** 3     
 
 
-  result: 5.05.min
+result: 5.05.min
 result: 4.95.min
 result: 15.min
 result: 1.6666666666666667.min
@@ -199,8 +199,14 @@ xyKibibytes = (x + y).kib
 dodo {
   name = "Dodo"
   taxonomy { 
-    `class` = "Aves" 
+    `class` = new Bird {}
   }
+}
+
+pidgeon {
+  name = "hello"
+} {
+  extinct = false
 }
 
 tortoise = (dodo) { 
@@ -551,7 +557,8 @@ obj: Bird                      // = new Bird {}
 nullable: Bird?                // = Null(new Bird {}) 
 union: *Bird|String            // = new Bird {} 
 stringLiteral: "Pigeon"        // = "Pigeon" 
-nullish: Null                  // = null 
+nullish: Null                  // = null
+mixup: Set<String|*Uri, *UInt16|Bird>
 
 
 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -581,6 +581,9 @@ parrot {
   when (isSinger) {
     hobby = "singing"
     idol = "Frank Sinatra"
+  } else {
+    hobby = "whistling"
+    idol = "Amadeus Mozart"
   }
 }
 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -559,6 +559,7 @@ union: *Bird|String            // = new Bird {}
 stringLiteral: "Pigeon"        // = "Pigeon" 
 nullish: Null                  // = null
 mixup: Set<String|*Uri, *UInt16|Bird>(this <= 9000)
+nested: Listing<Mapping<String, Base>>
 
 
 class Bird {

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -90,7 +90,6 @@ Although the Dodo is extinct,
 the species will be remembered.
 """
 
-
 bird = "Dodo"
 message = """
 Although the \(bird) is extinct,

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -80,7 +80,7 @@ res5 = true.implies(false)
 
 
 name = "Dodo"
-greeting = "Hi, \(name)!" 
+greeting = "Hi, \(name)!"
 
 x = 42
 str = "\(x + 2) plus \(x * 2) is \(0x80)" 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -558,8 +558,7 @@ nullable: Bird?                // = Null(new Bird {})
 union: *Bird|String            // = new Bird {} 
 stringLiteral: "Pigeon"        // = "Pigeon" 
 nullish: Null                  // = null
-mixup: Set<String|*Uri, *UInt16|Bird>
-
+mixup: Set<String|*Uri, *UInt16|Bird>(this <= 9000)
 
 
 class Bird {

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -622,7 +622,7 @@ entries2 {
 elements1 { 1; 2 }
 
 elements2 {
-  ...elements1 
+  ...?elements1
 }
 
 properties1 {

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -169,6 +169,7 @@ comparison2 = 5.mb < 3.kib
 comparison3 = 5.mb > 3.kib
 comparison4 = 5.mb <= 3.kib
 comparison5 = 5.mb >= 3.kib
+comparison6 = 5.mb != 3.kib
 
 res1 = 5.mb + 3.kib 
 res2 = 5.mb - 3.kib 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -509,9 +509,10 @@ test8 = derived is Derived
 test9 = derived is Base
 test10 = derived is Any
 
-test1 = email is String(contains("@")) 
+test1 = email is String(contains("@"))
 test2 = map is Map<Int, Base> 
 test3 = name is "Pigeon"|"Barn owl"|"Parrot"
+text4 = `quoted name` is Base
 
 birds {
   new { name = "Pigeon" }
@@ -647,7 +648,7 @@ updated = (environmentVariables) {
 `A Bird's First Flight Time` = 5.s
 
 `number` = 42 
-res1 = `number` 
+res1 = `number`.min
 res2 = number 
 
 /// An aviated animal going by the name of [bird](https://en.wikipedia.org/wiki/Bird).
@@ -658,7 +659,7 @@ module com.animals.Birds
 /// A bird living on Earth.
 ///
 /// Has [name] and [lifespan] properties and an [isOlderThan()] method.
-class Bird {
+class `class` {
   /// The name of this bird.
   name: String
 

--- a/example/tmLanguage.pkl
+++ b/example/tmLanguage.pkl
@@ -178,7 +178,7 @@ hidden skipIfEmpty = (v: Dynamic|Typed|String) ->
     if (isEmpty) null else v
 
 output {
-  renderer = new PListRenderer {
+  renderer = new YamlRenderer {
     converters {
       [String] = skipIfEmpty
       [Map] = skipIfEmpty

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -35,6 +35,7 @@ contexts:
     - include: operator
     - include: quoted-identifiers
     - include: identifiers
+    - include: brackets
 
   comments:
     - match: //.*
@@ -269,7 +270,7 @@ contexts:
       scope: storage.type.pkl
     - match: \b(Any|nothing)\b
       scope: storage.type.class.pkl
-    - match: '{{ident}}\b'
+    - match: '\b{{ident}}\b'
       scope: entity.name.type.pkl
     - match: '\|'
       scope: punctuation.separator.sequence.pkl
@@ -306,11 +307,9 @@ contexts:
   generic-angles-contents:
     - match: '(?=>)'
       pop: true
-    - include: type
-    - include: generic-angles
     - match: '(,)\s*'
       scope: punctuation.separator.pkl
-      push: after-expression
+    - include: type
 
   typealias:
     - match: '(typealias)\s+({{ident}})\s*(=)\s*({{type}})'
@@ -379,3 +378,19 @@ contexts:
       push: type
     - match: ''
       pop: true
+
+  brackets:
+    - match: \(
+      scope: punctuation.section.parens.begin.pkl
+      push:
+        - match: \)
+          scope: punctuation.section.parens.end.pkl
+          set: after-expression
+        - include: main
+    - match: \[
+      scope: punctuation.section.brackets.begin.pkl
+      push:
+        - match: \]
+          scope: punctuation.section.brackets.end.pkl
+          set: after-expression
+        - include: main

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -6,12 +6,13 @@ name: Pkl
 file_extensions: [pkl, pcf]
 scope: source.pkl
 
+variables:
+  escape-chars: '(?:\\|\\#|\\##|\\###|\\####|\\#####|\\######)'
 contexts:
   main:
     - include: comments
-    - include: string-quoted-single
-    - include: string-double
-    - include: string-block
+    - include: custom-string-1
+    - include: strings
     - include: keyword
     - include: class
     - include: literal
@@ -52,48 +53,118 @@ contexts:
     - match: \*/
       scope: invalid.illegal.pkl
 
+
   escaped-char:
-    - match: '\\[\\"''tnr]'
+    - match: '[\\"tnr]'
       scope: constant.character.escape.pkl
+      pop: true
 
   escaped-unicode-char:
-    - match: '\\u\{\h{1,6}\}'
+    - match: 'u\{\h{1,6}\}'
       scope: constant.character.escape.unicode.pkl
+      pop: true
 
   string-interpolation:
-    - match: \\\(
+    - match: \(
       push:
         - clear_scopes: 1
         - meta_scope: meta.interpolation.pkl
         - match: \)
           scope: punctuation.section.interpolation.end.pkl
-          pop: true
+          pop: 2 # pops both the ( and the {escape}
         - include: main
 
-  string-double:
+  escape-char-0:
+    - match: '\\'
+      scope: constant.character.escape.pkl
+      push:
+        - include: string-interpolation
+        - include: escaped-char
+        - include: escaped-unicode-char
+
+  escape-char-1:
+    - match: '\\#'
+      scope: constant.character.escape.pkl
+      push:
+        - include: string-interpolation
+        - include: escaped-char
+        - include: escaped-unicode-char
+
+  escape-char-2:
+    - match: '\\##'
+      scope: constant.character.escape.pkl
+      push:
+        - include: string-interpolation
+        - include: escaped-char
+        - include: escaped-unicode-char
+
+  strings:
+    - include: string-quoted
+    - include: string-multi-line-2
+    - include: string-single-line-2
+    - include: string-multi-line-1
+    - include: string-single-line-1
+    - include: string-multi-line-0
+    - include: string-single-line-0
+
+  string-single-line-0:
     - match: '"'
-      scope: string.quoted.double.pkl punctuation.definition.string.begin.pkl
+      scope: string.quoted.double.0.pkl punctuation.definition.string.begin.0.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.double.pkl
+        - meta_content_scope: meta.string.pkl string.quoted.double.0.pkl
         - match: '"'
-          scope: punctuation.definition.string.end.pkl
+          scope: punctuation.definition.string.end.0.pkl
           pop: true
-        - include: string-interpolation
-        - include: escaped-char
-        - include: escaped-unicode-char
+        - include: escape-char-0
 
-  string-block:
-    - match: '"""'
-      scope: string.quoted.triple.pkl punctuation.definition.string.begin.pkl
+  string-single-line-1:
+    - match: '#"'
+      scope: string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.triple.pkl
-        - match: '"""'
-          scope: punctuation.definition.string.end.pkl
+        - meta_content_scope: meta.string.pkl string.quoted.double.1.pkl
+        - match: '"#'
+          scope: punctuation.definition.string.end.1.pkl
           pop: true
-        - include: string-interpolation
-        - include: escaped-char
-        - include: escaped-unicode-char
+        - include: escape-char-1
 
+  string-single-line-2:
+  - match: '##"'
+    scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
+    push:
+      - meta_content_scope: meta.string.pkl string.quoted.double.2.pkl
+      - match: '"##'
+        scope: punctuation.definition.string.end.2.pkl
+        pop: true
+      - include: escape-char-2
+
+  string-multi-line-0:
+    - match: '(""")\s*?$' # content must start on a new line
+      scope: string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
+      push:
+        - meta_content_scope: meta.string.pkl string.quoted.triple.0.pkl
+        - match: '^\s*?(""")' # closing delim must start on a new line
+          scope: punctuation.definition.string.end.0.pkl
+          pop: true
+        - include: escape-char-0
+
+  string-multi-line-1:
+    - match: '(#""")\s*?$' # content must start on a new line
+      scope: string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
+      push:
+        - meta_content_scope: meta.string.pkl string.quoted.triple.1.pkl
+        - match: '^\s*?("""#)' # closing delim must start on a new line
+          scope: punctuation.definition.string.end.1.pkl
+          pop: true
+        - include: escape-char-1
+  string-multi-line-2:
+    - match: '(##""")\s*?$' # content must start on a new line
+      scope: string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
+      push:
+        - meta_content_scope: meta.string.pkl string.quoted.triple.2.pkl
+        - match: '^\s*?("""##)' # closing delim must start on a new line
+          scope: punctuation.definition.string.end.2.pkl
+          pop: true
+        - include: escape-char-2
 
   string-quoted:
     - match: \`
@@ -103,9 +174,7 @@ contexts:
         - match: \`
           scope: punctuation.definition.string.end.pkl
           pop: true
-        - include: string-interpolation
-        - include: escape_captures
-        - include: escaped-unicode-char
+        - include: escape-char-0
 
   all:
     - match: ([_\w]+)\s*([=:{])

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -13,7 +13,8 @@ variables:
   hexa: '(?:[\da-fA-F][\da-fA-F_]*[\da-fA-F]|[\da-fA-F_])'
 
   variable: '(?:[\p{L}_$][\p{L}0-9_$]*)' # can't start with a number
-  baseType: '(?:{{variable}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
+  # baseType: '(?:{{variable}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
+  baseType: '(?:\*?{{variable}}\s*(?:<[^>]*>)?)' # eg: Listing<Mapping>(something)?
   type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*)' # eg: Listing<Float>|Mapping<Int>?|Duration
 
 contexts:
@@ -24,7 +25,9 @@ contexts:
     - include: variableDeclType
     - include: genericTypeMatch
     - include: forPattern
-    - include: method
+    - include: newPattern
+    - include: functions
+    - include: lambda-function
     - include: class
     - include: comments
     - include: strings
@@ -52,17 +55,15 @@ contexts:
           scope: punctuation.definition.comment.end.pkl
           pop: true
     - include: comment-error
+
   comment-error:
     - match: \*/
       scope: invalid.illegal.pkl
-
 
   escaped-char:
     - match: '[\\"tnr]'
       scope: constant.character.escape.pkl
       pop: true
-
-  escaped-unicode-char:
     - match: 'u\{[\da-fA-F]{1,6}\}'
       scope: constant.character.escape.unicode.pkl
       pop: true
@@ -74,7 +75,7 @@ contexts:
         - meta_scope: meta.interpolation.pkl
         - match: \)
           scope: punctuation.section.interpolation.end.pkl
-          pop: 2 # pops both the ( and the {escape}
+          pop: 2 # pops both the ( and the {escape-char}
         - include: main
 
   escape-char-0:
@@ -83,7 +84,6 @@ contexts:
       push:
         - include: string-interpolation
         - include: escaped-char
-        - include: escaped-unicode-char
 
   escape-char-1:
     - match: '\\#'
@@ -91,7 +91,6 @@ contexts:
       push:
         - include: string-interpolation
         - include: escaped-char
-        - include: escaped-unicode-char
 
   escape-char-2:
     - match: '\\##'
@@ -99,7 +98,6 @@ contexts:
       push:
         - include: string-interpolation
         - include: escaped-char
-        - include: escaped-unicode-char
 
   strings:
     - include: string-quoted
@@ -159,6 +157,7 @@ contexts:
           scope: punctuation.definition.string.end.1.pkl
           pop: true
         - include: escape-char-1
+
   string-multi-line-2:
     - match: '(##""")\s*?$' # content must start on a new line
       scope: string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
@@ -240,24 +239,28 @@ contexts:
       scope: keyword.pkl
 
   type:
-    - match: \b(Int|String|Boolean|Float)\b
+    - match: \b(Int|String|Boolean|Float|Number|Any|Base)\b
       scope: storage.type.pkl
     - match: \b(UInt16|UInt8|UInt)\b
       scope: storage.type.pkl
+    - match: \b(Collection|List|Set|Map|Listing|Mapping)\b
+      scope: entity.name.type.pkl
 
   keyword:
     - match: \b(|protected|override|record|delete|match|case|vararg|const)\b
       scope: keyword.other.pkl
-    - match: '\b(amends|as|extends|function|is|let|read|read\\?|import|import\*|throw|trace)\b'
-      scope: keyword.pkl
+    - match: '\b(read\?|read\*|read|import\*)\b?'
+      scope: keyword.import.pkl
     - match: \b(if|else|for|when)\b
       scope: keyword.control.conditional.pkl
     - match: \b(hidden|local|abstract|external|open|in|out|amends|extends|fixed)\b
       scope: storage.modifier.pkl
     - match: \b(class|typealias)\b
       scope: keyword.declaration.class.pkl
+    - match: '\b(amends|as|extends|function|is|let|read|import|throw|trace)\b'
+      scope: keyword.pkl
     - match: \b(this|module|outer|super)\b
-      scope: variable.language.pkl keyword.pkl
+      scope: variable.language.pkl
 
   module:
     - match: '(?:(module)\s+({{variable}}(?:\.{{variable}}))?)'
@@ -276,7 +279,7 @@ contexts:
         4: entity.name.type.pkl
 
   variableDecl:
-    - match: '(\b{{variable}}|`[^`]+`)\s*(=)(?!=)'
+    - match: '(\b{{variable}}|`[^`]+`)\s*(?:(=)(?!=)|(?={))'
       captures:
         0: meta.variable.declaration.pkl
         1: variable.other.property.pkl
@@ -305,26 +308,32 @@ contexts:
         2: variable.other.property.pkl
         3: variable.other.property.pkl
         4: storage.modifier.pkl
-  method:
-    - match: '\b(function)\s+({{variable}})\(([^)]*)\)'
+
+  functions:
+    - match: '\b(function)\s+({{variable}})'
       captures:
         0: meta.function.pkl
         1: keyword.pkl
         2: entity.name.function.pkl
-        3: meta.function.parameters.pkl
+
+  lambda-function:
+    - match: '(\({{variable}}\))\s*\->\s*'
+      captures:
+        0: meta.function.anonymous.pkl
+        1: variable.other.pkl
 
   class:
-    - match: '^(?:(open|))\s*(class)?\s+([A-Za-z0-9]{1,})(?:\s*(extends|))(?:\s*([A-Za-z0-9]{1,}|)):?$\n?'
+    - match: '(open)?(class)\s+(\w+)(?:\s*(extends)\s+(\w+))?'
       captures:
         0: meta.class.pkl
-        1: keyword
+        1: keyword.other.pkl
         2: keyword.declaration.class.pkl
-        3: support.class.pkl
-        4: keyword
-        5: support.class.pkl
+        3: entity.name.class.pkl
+        4: keyword.pkl
+        5: support.type.pkl
 
-# TODO:
-#   -better matching for union types
-#   -Type constraints not marked as type?
-#   -class declaration patter matcher
-#   -lambda pattern matcher
+  newPattern:
+    - match: '\b(new)\s+({{variable}})?'
+      captures:
+        1: keyword.pkl
+        2: support.type.pkl

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -1,7 +1,6 @@
 %YAML 1.2
 ---
 # Syntax: sublimetext.com/docs/syntax.html
-# Documentation: docs.toit.io/language
 
 name: Pkl
 file_extensions:
@@ -36,20 +35,20 @@ contexts:
 
   comment-multi-line:
     - match: /\*
-      scope: punctuation.definition.comment.begin.toit
+      scope: punctuation.definition.comment.begin.pkl
       push:
-        - meta_scope: comment.block.toit
+        - meta_scope: comment.block.pkl
         - match: \*/
-          scope: punctuation.definition.comment.end.toit
+          scope: punctuation.definition.comment.end.pkl
           pop: true
         - match: '^\s*(\*)(?!/)'
           captures:
-            0: punctuation.definition.comment.toit
+            0: punctuation.definition.comment.pkl
     - include: comment-error
 
   comment-error:
     - match: \*/
-      scope: invalid.illegal.toit
+      scope: invalid.illegal.pkl
 
   string-double:
     - match: '"'
@@ -96,7 +95,7 @@ contexts:
 
   built-in:
     - match: \b(JsonRenderer|YamlRenderer)\b
-      scope: support.class.toit
+      scope: support.class.pkl
 
   operator:
     - match: '([+*/%-:&|^]|<<|>>>?)='
@@ -172,7 +171,7 @@ contexts:
         0: meta.function.pkl
         1: storage.modifier.pkl
         2: keyword.pkl
-        3: entity.name.function.toit
+        3: entity.name.function.pkl
         4: punctuation.section.parens.begin.pkl
 
   class:

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -60,7 +60,6 @@ contexts:
     - match: '\\u\{\h{1,6}\}'
       scope: constant.character.escape.unicode.pkl
 
-
   string-interpolation:
     - match: \\\(
       push:
@@ -119,11 +118,11 @@ contexts:
     - match: (?:(?:[-]?)(?:[0-9e]*)(?:\.{1}){1}(?:[0-9e]+))
       scope: constant.numeric.float.decimal.pkl
     - match: \b(?:0[xX])(?:[_0-9a-fA-F]+)
-      scope: constant.numeric.hex.pkl
+      scope: constant.numeric.integer.hex.pkl
     - match: \b(?:0[bB])(?:[_0-9a-fA-F]+)
-      scope: constant.numeric.binary.pkl
+      scope: constant.numeric.integer.binary.pkl
     - match: \b(?:0[oO])(?:[_0-9a-fA-F]+)
-      scope: constant.numeric.octal.pkl
+      scope: constant.numeric.integer.octal.pkl
     - match: \b(?:[-]?)(?:[0-9_]+)
       scope: constant.numeric.integer.decimal.pkl
 

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -26,6 +26,7 @@ contexts:
     - include: forPattern
     - include: method
     - include: class
+    - include: comments
     - include: strings
     - include: keyword
     - include: literal
@@ -33,7 +34,6 @@ contexts:
     - include: super
     - include: type
     - include: operator
-    - include: comments
 
   comments:
     - include: comment-single-line
@@ -180,21 +180,15 @@ contexts:
         - include: escape-char-0
 
   number:
-    - match: '
-      \b(?:
-        {{digits}}?\.
-        {{digits}}(?:[eE][+-]?{{digits}})?
-        |
-        {{digits}}[eE][+-]?{{digits}}
-      )\b'
+    - match: '(?:{{digits}}?\.{{digits}}(?:[eE][+-]?{{digits}})?|{{digits}}[eE][+-]?{{digits}})'
       scope: constant.numeric.float.pkl
-    - match: \b(?:0[xX]){{hexa}}
+    - match: '(?:0[xX]){{hexa}}'
       scope: constant.numeric.integer.hex.pkl
-    - match: \b(?:0[bB]){{bits}}
+    - match: '(?:0[bB]){{bits}}'
       scope: constant.numeric.integer.binary.pkl
-    - match: \b(?:0[oO]){{octets}}
+    - match: '(?:0[oO]){{octets}}'
       scope: constant.numeric.integer.octal.pkl
-    - match: \b{{digits}}
+    - match: '{{digits}}'
       scope: constant.numeric.integer.decimal.pkl
 
   operator:

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -37,12 +37,14 @@ contexts:
     - include: lambda-function
     - include: class-declaration
     - include: object-declaration
+    - include: member-predicate
     - include: comments
     - include: strings
     - include: keyword
     - include: constants
     - include: super
     - include: operator
+    - include: punctuation
     - include: identifiers
     - include: brackets
 
@@ -109,61 +111,61 @@ contexts:
 
   string-single-line-0:
     - match: '"'
-      scope: meta.string.pkl string.quoted.double.0.pkl punctuation.definition.string.begin.0.pkl
+      scope: string.quoted.double.0.pkl punctuation.definition.string.begin.0.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.double.0.pkl
+        - meta_content_scope: string.quoted.double.0.pkl
         - match: '"'
-          scope: meta.string.pkl string.quoted.double.0.pkl punctuation.definition.string.end.0.pkl
+          scope: string.quoted.double.0.pkl punctuation.definition.string.end.0.pkl
           pop: true
         - include: escape-char-0
 
   string-single-line-1:
     - match: '#"'
-      scope: meta.string.pkl string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
+      scope: string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.double.1.pkl
+        - meta_content_scope: string.quoted.double.1.pkl
         - match: '"#'
-          scope: meta.string.pkl string.quoted.double.1.pkl punctuation.definition.string.end.1.pkl
+          scope: string.quoted.double.1.pkl punctuation.definition.string.end.1.pkl
           pop: true
         - include: escape-char-1
 
   string-single-line-2:
     - match: '##"'
-      scope: meta.string.pkl string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
+      scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.double.2.pkl
+        - meta_content_scope: string.quoted.double.2.pkl
         - match: '"##'
-          scope: meta.string.pkl string.quoted.double.2.pkl punctuation.definition.string.end.2.pkl
+          scope: string.quoted.double.2.pkl punctuation.definition.string.end.2.pkl
           pop: true
         - include: escape-char-2
 
   string-multi-line-0:
     - match: '(""")\s*?$' # content must start on a new line
-      scope: meta.string.pkl string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
+      scope: string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.triple.0.pkl
+        - meta_content_scope: string.quoted.triple.0.pkl
         - match: '^\s*?(""")' # closing delim must start on a new line
-          scope: meta.string.pkl string.quoted.triple.0.pkl punctuation.definition.string.end.0.pkl
+          scope: string.quoted.triple.0.pkl punctuation.definition.string.end.0.pkl
           pop: true
         - include: escape-char-0
 
   string-multi-line-1:
     - match: '(#""")\s*?$' # content must start on a new line
-      scope: meta.string.pkl string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
+      scope: string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.triple.1.pkl
+        - meta_content_scope: string.quoted.triple.1.pkl
         - match: '^\s*?("""#)' # closing delim must start on a new line
-          scope: meta.string.pkl string.quoted.triple.1.pkl punctuation.definition.string.end.1.pkl
+          scope: string.quoted.triple.1.pkl punctuation.definition.string.end.1.pkl
           pop: true
         - include: escape-char-1
 
   string-multi-line-2:
     - match: '(##""")\s*?$' # content must start on a new line
-      scope: meta.string.pkl string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
+      scope: string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
       push:
-        - meta_content_scope: meta.string.pkl string.quoted.triple.2.pkl
+        - meta_content_scope: string.quoted.triple.2.pkl
         - match: '^\s*?("""##)' # closing delim must start on a new line
-          scope: meta.string.pkl string.quoted.triple.2.pkl punctuation.definition.string.end.2.pkl
+          scope: string.quoted.triple.2.pkl punctuation.definition.string.end.2.pkl
           pop: true
         - include: escape-char-2
 
@@ -193,7 +195,7 @@ contexts:
       scope: constant.language.infinity.pkl
 
   operator:
-    - match: '\|>|\?\.|\?\?|!!|\->|\|'
+    - match: \.\.\.\?|\.\.\.|'\|>|\?\.|\?\?|!!|\->|\|'
       scope: keyword.operator.pkl
     - match: '(==|!=|<=|>=|>|<)'
       scope: keyword.operator.comparison
@@ -224,6 +226,11 @@ contexts:
     - match: \b(this|outer|super)\b
       scope: variable.language.pkl
 
+  punctuation:
+    - match: ';'
+      scope: punctuation.terminator.pkl
+
+
   super:
     - match: \@({{base_ident}})
       scope: keyword.pkl
@@ -236,6 +243,16 @@ contexts:
         - match: '`'
           scope: punctuation.section.quoted.end.pkl
           set: after-expression
+    - match: '\[(?!\[)'
+      scope: punctuation.section.brackets.begin.pkl
+      push:
+        - meta_content_scope: variable.other.entry.pkl
+        - match: '\]'
+          scope: punctuation.section.brackets.end.pkl
+          pop: true
+        - match: '{{ident}}'
+          scope: variable.other.key.pkl
+        - include: strings
     - match: '{{ident}}\s*(?==)'
       scope: variable.other.property.pkl
     - match: '{{ident}}\s*(?={)'
@@ -367,6 +384,16 @@ contexts:
         3: punctuation.section.quoted.end.pkl
         4: keyword.pkl
       push: type
+
+  member-predicate:
+    - match: '\[\['
+      scope: punctuation.section.group.begin.pkl
+      push:
+        - meta_content_scope: meta.member-predicate.pkl
+        - match: '\]\]'
+          scope: punctuation.section.group.end.pkl
+          pop: true
+        - include: main
 
   after-expression:
     - match: (\.)(?={{ident}})

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -7,7 +7,15 @@ file_extensions: [pkl, pcf]
 scope: source.pkl
 
 variables:
-  escape-chars: '(?:\\|\\#|\\##|\\###|\\####|\\#####|\\######)'
+  digits: '(?:\d[\d_]*\d|\d)'
+  bits: '(?:[0-1][0-1_]*[0-1]|[0-1])'
+  octets: '(?:[0-7][0-7_]*[0-7]|[0-7])'
+  hexa: '(?:[\da-fA-F][\da-fA-F_]*[\da-fA-F]|[\da-fA-F_])'
+
+  variable: '(?:[\p{L}_$][\p{L}0-9_$]*)' # can't start with a number
+  baseType: '(?:{{variable}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
+  type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*' # eg: Listing<Float>|Mapping<Int>?|Duration
+
 contexts:
   main:
     - include: comments
@@ -174,15 +182,21 @@ contexts:
         1: variable.pkl
 
   number:
-    - match: (?:(?:[-]?)(?:[0-9e]*)(?:\.{1}){1}(?:[0-9e]+))
-      scope: constant.numeric.float.decimal.pkl
-    - match: \b(?:0[xX])(?:[_0-9a-fA-F]+)
+    - match: '
+      \b(?:
+        {{digits}}?\.
+        {{digits}}(?:[eE][+-]?{{digits}})?
+        |
+        {{digits}}[eE][+-]?{{digits}}
+      )\b'
+      scope: constant.numeric.float.pkl
+    - match: \b(?:0[xX]){{hexa}}
       scope: constant.numeric.integer.hex.pkl
-    - match: \b(?:0[bB])(?:[_0-9a-fA-F]+)
+    - match: \b(?:0[bB]){{bits}}
       scope: constant.numeric.integer.binary.pkl
-    - match: \b(?:0[oO])(?:[_0-9a-fA-F]+)
+    - match: \b(?:0[oO]){{octets}}
       scope: constant.numeric.integer.octal.pkl
-    - match: \b(?:[-]?)(?:[0-9_]+)
+    - match: \b{{digits}}
       scope: constant.numeric.integer.decimal.pkl
 
   built-in:
@@ -204,14 +218,14 @@ contexts:
       scope: keyword.operator.logical
 
   punctuation:
-    - match: \.
-      scope: punctuation.delimiter.period.dot.pkl
+    - match: '\.\b'
+      scope: punctuation.accessor
     - match: \,
-      scope: punctuation.delimiter.comma.pkl
+      scope: punctuation.separator.comma.pkl
     - match: \;
-      scope: punctuation.definition.other.semicolon.pkl
+      scope: punctuation.terminator.semicolon.pkl
     - match: ':'
-      scope: punctuation.separator.key-value.colon.pkl
+      scope: punctuation.separator.colon.pkl
     - match: \(
       scope: punctuation.section.parens.begin.pkl
     - match: \)
@@ -222,14 +236,6 @@ contexts:
       scope: punctuation.section.brackets.end.pkl
     - match: \?
       scope: punctuation.definition.other.questionmark.pkl
-      # =
-      # <
-      # >
-      # /
-      # +
-      # {
-      # }
-      # ->
 
   literal:
     - match: \b(true|false)\b
@@ -256,14 +262,16 @@ contexts:
       scope: keyword.pkl
     - match: \b(if|else|for|when|switch|case)\b
       scope: keyword.control.conditional.pkl
-    - match: \b(import|module|new)\b
+    - match: \b(import|new)\b
       scope: keyword.control.import.pkl
     - match: \b(is|as|in)\b
       scope: keyword.import.from.pkl
     - match: \b(hidden|local|abstract|external|open|in|out|amends|extends|fixed)\b
       scope: storage.modifier.pkl
-    - match: \b(class)\b
-      scope: keyword.pkl
+    - match: \b(class|typealias)\b
+      scope: keyword.declaration.class.pkl
+    - match: \b(this|module|outer|super)\b
+      scope: variable.language.pkl
 
   method:
     - match: '^(?:(const|))(?:(function|))\s+([A-Za-z0-9]{1,}(\(\)){1})'

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -19,11 +19,10 @@ variables:
 
 contexts:
   main:
-    - include: module
     - include: typealias
-    - include: type-decl
     - include: forPattern
     - include: newPattern
+    - include: isPattern
     - include: functions
     - include: lambda-function
     - include: class
@@ -60,6 +59,7 @@ contexts:
 
   string-interpolation:
     - match: \(
+      scope: punctuation.section.interpolation.begin.pkl
       push:
         - clear_scopes: 1
         - meta_scope: meta.interpolation.pkl
@@ -99,61 +99,61 @@ contexts:
 
   string-single-line-0:
     - match: '"'
-      scope: string.quoted.double.0.pkl punctuation.definition.string.begin.0.pkl
+      scope: meta.string.pkl string.quoted.double.0.pkl punctuation.definition.string.begin.0.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.double.0.pkl
         - match: '"'
-          scope: punctuation.definition.string.end.0.pkl
+          scope: meta.string.pkl string.quoted.double.0.pkl punctuation.definition.string.end.0.pkl
           pop: true
         - include: escape-char-0
 
   string-single-line-1:
     - match: '#"'
-      scope: string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
+      scope: meta.string.pkl string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.double.1.pkl
         - match: '"#'
-          scope: punctuation.definition.string.end.1.pkl
+          scope: meta.string.pkl string.quoted.double.1.pkl punctuation.definition.string.end.1.pkl
           pop: true
         - include: escape-char-1
 
   string-single-line-2:
     - match: '##"'
-      scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
+      scope: meta.string.pkl string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.double.2.pkl
         - match: '"##'
-          scope: punctuation.definition.string.end.2.pkl
+          scope: meta.string.pkl string.quoted.double.2.pkl punctuation.definition.string.end.2.pkl
           pop: true
         - include: escape-char-2
 
   string-multi-line-0:
     - match: '(""")\s*?$' # content must start on a new line
-      scope: string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
+      scope: meta.string.pkl string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.triple.0.pkl
         - match: '^\s*?(""")' # closing delim must start on a new line
-          scope: punctuation.definition.string.end.0.pkl
+          scope: meta.string.pkl string.quoted.triple.0.pkl punctuation.definition.string.end.0.pkl
           pop: true
         - include: escape-char-0
 
   string-multi-line-1:
     - match: '(#""")\s*?$' # content must start on a new line
-      scope: string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
+      scope: meta.string.pkl string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.triple.1.pkl
         - match: '^\s*?("""#)' # closing delim must start on a new line
-          scope: punctuation.definition.string.end.1.pkl
+          scope: meta.string.pkl string.quoted.triple.1.pkl punctuation.definition.string.end.1.pkl
           pop: true
         - include: escape-char-1
 
   string-multi-line-2:
     - match: '(##""")\s*?$' # content must start on a new line
-      scope: string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
+      scope: meta.string.pkl string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.triple.2.pkl
         - match: '^\s*?("""##)' # closing delim must start on a new line
-          scope: punctuation.definition.string.end.2.pkl
+          scope: meta.string.pkl string.quoted.triple.2.pkl punctuation.definition.string.end.2.pkl
           pop: true
         - include: escape-char-2
 
@@ -169,6 +169,16 @@ contexts:
     - match: '\b{{digits}}\b'
       scope: constant.numeric.integer.decimal.pkl
 
+  literal:
+    - match: \b(true|false)\b
+      scope: constant.language.boolean.pkl
+    - match: \b(null)\b
+      scope: constant.language.null.pkl
+    - match: \b(NaN)\b
+      scope: constant.language.nan.pkl
+    - match: \b(Infinity)\b
+      scope: constant.language.infinity.pkl
+
   operator:
     - match: '\|>|\?\.|\?\?|!!|\->|\|'
       scope: keyword.operator.pkl
@@ -183,9 +193,25 @@ contexts:
     - match: '\!|\&\&|\|\|'
       scope: keyword.operator.logical
 
+  keyword:
+    - match: \b(|protected|override|record|delete|match|case|vararg|const)\b
+      scope: keyword.other.pkl
+    - match: '\b(read\?|read\*|read|import\*)\b?'
+      scope: keyword.import.pkl
+    - match: \b(if|else|when)\b
+      scope: keyword.control.conditional.pkl
+    - match: \b(for)\b
+      scope: keyword.control.loop.pkl
+    - match: \b(hidden|local|abstract|external|open|in|out|amends|extends|fixed)\b
+      scope: storage.modifier.pkl
+    - match: \b(class|typealias)\b
+      scope: storage.type.class.pkl keyword.declaration.class.pkl
+    - match: '\b(amends|as|extends|function|is|let|read|import|throw|trace|module)\b'
+      scope: keyword.pkl
+    - match: \b(this|outer|super)\b
+      scope: variable.language.pkl
+
   punctuation:
-    - match: '\b\.\b'
-      scope: punctuation.accessor
     - match: \,
       scope: punctuation.separator.comma.pkl
     - match: \;
@@ -203,29 +229,19 @@ contexts:
     - match: \?
       scope: punctuation.definition.other.questionmark.pkl
 
-  literal:
-    - match: \b(true|false)\b
-      scope: constant.language.boolean.pkl
-    - match: \b(null)\b
-      scope: constant.language.null.pkl
-    - match: \b(NaN)\b
-      scope: constant.language.nan.pkl
-    - match: \b(Infinity)\b
-      scope: constant.language.infinity.pkl
-
   super:
     - match: \@({{ident}})
       scope: keyword.pkl
 
   identifiers:
     - match: '({{ident}})\s*(?=`?{)'
-      scope: variable.object.pkl
+      scope: variable.other.object.pkl
       push: after-expression
     - match: '({{ident}})\s*(?=`?=\s*(?:new|\([^)]+\)\s*{))'
-      scope: variable.object.pkl
+      scope: variable.other.object.pkl
       push: after-expression
     - match: '({{ident}})\s*(?=`?=)'
-      scope: variable.property.pkl
+      scope: variable.other.property.pkl
       push: after-expression
     - match: '{{ident}}'
       scope: meta.identifier.pkl
@@ -242,15 +258,27 @@ contexts:
         - include: identifiers
 
   type:
-    - match: \b(\*?(?:Pair|Collection|List|Set|Map|Listing|Mapping))\b
-      scope: support.type.pkl
-      push: generic-angles
-    - match: \b(\*?(?:U?Int(?:8|16|32)?|String|Uri|Boolean|Float|Number|Any|Base))\b
+    - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping)\b
       scope: storage.type.pkl
-    - match: '\*?{{ident}}\b'
-      scope: support.type.pkl
+      push:
+        - match: '(?=<)'
+          push: generic-angles
+        - match: ''
+          pop: true
+    - match: \b(U?Int(?:8|16|32)?|String|Uri|Boolean|Float|Number)\b
+      scope: storage.type.pkl
+    - match: \b(Any|nothing)\b
+      scope: storage.type.class.pkl
+    - match: '{{ident}}\b'
+      scope: entity.name.type.pkl
     - match: '\|'
       scope: punctuation.separator.sequence.pkl
+    - match: '\*'
+      scope: punctuation.definition.annotation.pkl
+    - match: '(?=\()'
+      push: type-constraint
+    - match: ''
+      pop: true
 
   type-constraint:
     - meta_content_scope: meta.type.constraint.pkl
@@ -260,15 +288,11 @@ contexts:
     - match: '\('
       scope: punctuation.section.parens.begin.pkl
       push: type-constraint-contents
-    - match: '\s*(?=\S)'
-      pop: true
 
   type-constraint-contents:
-    - meta_content_scope: meta.type.constraint.pkl
-    - match: '\)'
-      scope: punctuation.section.parens.end.pkl
-      set: main
-
+    - match: '(?=\))'
+      pop: true
+    - include: main
 
   generic-angles:
     - meta_content_scope: meta.generic.pkl
@@ -278,40 +302,15 @@ contexts:
     - match: '<'
       scope: punctuation.definition.generic.begin.pkl
       push: generic-angles-contents
-    - match: ','
-      scope: punctuation.separator.pkl
-      pop: true
-    - match: '\|'
-      scope: punctuation.separator.sequence.pkl
-    - match: '\s*(?=\S)'
-      pop: true
 
   generic-angles-contents:
+    - match: '(?=>)'
+      pop: true
     - include: type
     - include: generic-angles
-
-  keyword:
-    - match: \b(|protected|override|record|delete|match|case|vararg|const)\b
-      scope: keyword.other.pkl
-    - match: '\b(read\?|read\*|read|import\*)\b?'
-      scope: keyword.import.pkl
-    - match: \b(if|else|for|when)\b
-      scope: keyword.control.conditional.pkl
-    - match: \b(hidden|local|abstract|external|open|in|out|amends|extends|fixed)\b
-      scope: storage.modifier.pkl
-    - match: \b(class|typealias)\b
-      scope: keyword.declaration.class.pkl
-    - match: '\b(amends|as|extends|function|is|let|read|import|throw|trace)\b'
-      scope: keyword.pkl
-    - match: \b(this|module|outer|super)\b
-      scope: variable.language.pkl
-
-  module:
-    - match: '(?:(module)\s+({{ident}}(?:\.{{ident}}))?)'
-      captures:
-        0: meta.module.pkl
-        1: variable.language.pkl
-        2: variable.other.module.pkl
+    - match: '(,)\s*'
+      scope: punctuation.separator.pkl
+      push: after-expression
 
   typealias:
     - match: '(typealias)\s+({{ident}})\s*(=)\s*({{type}})'
@@ -348,17 +347,26 @@ contexts:
     - match: '(?:(open)\s+)?(class)\s+({{ident}})(?:\s*(extends)\s+({{ident}}))?'
       captures:
         0: meta.class.pkl
-        1: keyword.other.pkl
-        2: keyword.declaration.class.pkl
+        1: storage.modifier.pkl keyword.other.pkl
+        2: storage.type.class.pkl keyword.declaration.class.pkl
         3: entity.name.class.pkl
-        4: keyword.pkl
-        5: support.type.pkl
+        4: storage.modifier.pkl keyword.other.pkl
+        5: entity.name.type.pkl
 
   newPattern:
     - match: '\b(new)\s+({{ident}})?'
       captures:
         1: keyword.pkl
-        2: support.type.pkl
+        2: entity.name.type.pkl
+
+  isPattern:
+    - match: '(`?)({{ident}})(`?)\s+(is)\s+'
+      captures:
+        1: punctuation.section.quoted.begin.pkl
+        2: variable.other.pkl
+        3: punctuation.section.quoted.end.pkl
+        4: keyword.pkl
+      push: type
 
   after-expression:
     - match: (\.)(?={{ident}})
@@ -366,11 +374,8 @@ contexts:
       push:
         - match: ''
           pop: true
-    - match: (\s*:\s*)
+    - match: \s*(:)\s*
       scope: punctuation.separator.pkl
-      push:
-        - include: type
-        - match: ''
-          pop: true
+      push: type
     - match: ''
       pop: true

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -168,7 +168,7 @@ contexts:
         - include: escape-char-0
 
   all:
-    - match: ([_\w]+)\s*([=:{])
+    - match: ([_\w]+)\s*(?=[=:{])
       captures:
         0: meta.pkl
         1: variable.pkl
@@ -191,6 +191,8 @@ contexts:
       scope: support.class.pkl
 
   operator:
+    - match: '(==|<|>|<=|>=)'
+      scope: keyword.operator.comparison
     - match: '([+*/%-:&|^]|<<|>>>?)='
       scope: keyword.operator.assignment
     - match: '[+*/%-]'
@@ -199,8 +201,6 @@ contexts:
       scope: keyword.operator.logical
     - match: '[~&|^]|<<|>>>?'
       scope: keyword.operator.bitwise
-    - match: '==|<|>|<=|>='
-      scope: keyword.operator.comparison
 
   punctuation:
     - match: \.
@@ -255,13 +255,13 @@ contexts:
       scope: keyword.pkl
     - match: \b(if|else|for|when|switch|case)\b
       scope: keyword.control.conditional.pkl
-    - match: \b(import|module|amends)\b
+    - match: \b(import|module|new)\b
       scope: keyword.control.import.pkl
     - match: \b(is|as|in)\b
       scope: keyword.import.from.pkl
-    - match: \b(const)\b
-      scope: storage.modifier.toit
-    - match: \b(class|extends|new)\b
+    - match: \b(hidden|local|abstract|external|open|in|out|amends|extends|fixed)\b
+      scope: storage.modifier.pkl
+    - match: \b(class)\b
       scope: keyword.pkl
 
   method:

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -12,7 +12,9 @@ variables:
   octets: '(?:[0-7][0-7_]*[0-7]|[0-7])'
   hexa: '(?:[\da-fA-F][\da-fA-F_]*[\da-fA-F]|[\da-fA-F_])'
 
-  ident: '(?:[\p{L}_$][\p{L}0-9_$]*\b)' # can't start with a number
+  base_ident: '(?:[\p{L}_$][\p{L}0-9_$]*\b)' # can't start with a number
+  quoted_ident: '(?:`(?:{{base_ident}}\s*)+`)'
+  ident: '(?:{{base_ident}}|{{quoted_ident}})'
   # baseType: '(?:{{ident}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
   baseType: '(?:\*?{{ident}}\s*(?:<[^>]*>)?)' # eg: Listing<Mapping>
   type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*)' # eg: Listing<Float>|Mapping<Int>?|Duration
@@ -26,23 +28,22 @@ variables:
 
   duration_unit: (?:ns|us|ms|s|min|h|d)
   data_size_unit: (?:b|kb|kib|mb|mib|gb|gib|tb|tib|pb|pib)
+
 contexts:
   main:
     - include: typealias
     - include: forPattern
-    - include: newPattern
     - include: isPattern
     - include: functions
     - include: lambda-function
-    - include: classPattern
+    - include: class-declaration
+    - include: object-declaration
     - include: comments
     - include: strings
     - include: keyword
-    - include: literal
-    - include: number
+    - include: constants
     - include: super
     - include: operator
-    - include: quoted-identifiers
     - include: identifiers
     - include: brackets
 
@@ -167,7 +168,7 @@ contexts:
           pop: true
         - include: escape-char-2
 
-  number:
+  constants:
     - match: '\b(?:{{digits}}?\.{{digits}}(?:[eE][+-]?{{digits}})?|{{digits}}[eE][+-]?{{digits}})\b'
       scope: constant.numeric.float.pkl
       push: after-expression
@@ -183,8 +184,6 @@ contexts:
     - match: '\b{{digits}}\b'
       scope: constant.numeric.integer.decimal.pkl
       push: after-expression
-
-  literal:
     - match: \b(true|false)\b
       scope: constant.language.boolean.pkl
     - match: \b(null)\b
@@ -226,61 +225,65 @@ contexts:
     - match: \b(this|outer|super)\b
       scope: variable.language.pkl
 
-  punctuation:
-    - match: \,
-      scope: punctuation.separator.comma.pkl
-    - match: \;
-      scope: punctuation.terminator.semicolon.pkl
-    - match: ':'
-      scope: punctuation.separator.colon.pkl
-    - match: \(
-      scope: punctuation.section.parens.begin.pkl
-    - match: \)
-      scope: punctuation.section.parens.end.pkl
-    - match: \[
-      scope: punctuation.section.brackets.begin.pkl
-    - match: \]
-      scope: punctuation.section.brackets.end.pkl
-    - match: \?
-      scope: punctuation.definition.other.questionmark.pkl
-
   super:
-    - match: \@({{ident}})
+    - match: \@({{base_ident}})
       scope: keyword.pkl
 
   identifiers:
-    - match: '({{ident}})\s*(?=`?{)'
-      scope: variable.other.object.pkl
-      push: after-expression
-    - match: '({{ident}})\s*(?=`?=\s*(?:new|\([^)]+\)\s*{))'
-      scope: variable.other.object.pkl
-      push: after-expression
-    - match: '({{ident}})\s*(?=`?=)'
-      scope: variable.other.property.pkl
-      push: after-expression
-    - match: '{{ident}}'
-      scope: meta.identifier.pkl
-      push: after-expression
-
-  quoted-identifiers:
     - match: '`'
       scope: punctuation.section.quoted.begin.pkl
       push:
-        - meta_content_scope: meta.quoted.pkl
+        - meta_content_scope: variable.other.quoted.pkl
         - match: '`'
           scope: punctuation.section.quoted.end.pkl
-          pop: true
-        - include: identifiers
+          set: after-expression
+    - match: '{{ident}}\s*(?==)'
+      scope: variable.other.property.pkl
+    - match: '{{ident}}\s*(?={)'
+      scope: variable.other.object.pkl
+    - match: '{{base_ident}}'
+      scope: variable.other.pkl
+      push: after-expression
+
+  class-declaration:
+    - match: '\b(open)\b'
+      scope: storage.modifier.pkl
+    - match: '\b(class)\s+({{ident}})(?:\s*(extends)\s+({{ident}}))?'
+      captures:
+        1: storage.type.class.pkl keyword.declaration.class.pkl
+        2: entity.name.class.pkl
+        3: storage.modifier.pkl
+        4: entity.name.class.pkl
+      push: class-block
+
+  class-block:
+    - match: '\{'
+      scope: punctuation.section.class.begin.pkl
+      set:
+        - meta_content_scope: meta.class.pkl
+        - match: '\}'
+          scope: punctuation.section.class.end.pkl
+          set: after-expression
+        - include: main
+    - match: ''
+      pop: true
+
+  object-declaration:
+    - match: '\b(new)\s+(?:(Dynamic)|({{ident}}))'
+      captures:
+        1: keyword.pkl
+        2: keyword.pkl
+        3: entity.name.class.pkl
 
   type:
-    - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping|Dynamic)\b
+    - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping)\b
       scope: storage.type.pkl
       push:
         - match: '(?=<)'
           push: generic-angles
         - match: ''
           pop: true
-    - match: \b(U?Int(?:8|16|32)?|String|Uri|Char|Comparable|Boolean|Float|Number)\b
+    - match: \b(U?Int(?:8|16|32)?|String|Uri|Char|Comparable|Boolean|Float|Number|Dynamic)\b
       scope: storage.type.pkl
     - match: \b(Any|nothing)\b
       scope: storage.type.class.pkl
@@ -299,7 +302,7 @@ contexts:
     - meta_content_scope: meta.type.constraint.pkl
     - match: '\)'
       scope: punctuation.section.parens.end.pkl
-      pop: true
+      set: after-expression
     - match: '\('
       scope: punctuation.section.parens.begin.pkl
       push: type-constraint-contents
@@ -313,7 +316,7 @@ contexts:
     - meta_content_scope: meta.generic.pkl
     - match: '>'
       scope: punctuation.definition.generic.end.pkl
-      pop: true
+      set: after-expression
     - match: '<'
       scope: punctuation.definition.generic.begin.pkl
       push: generic-angles-contents
@@ -351,26 +354,11 @@ contexts:
         2: entity.name.function.pkl
 
   lambda-function:
-    - match: '(\({{ident}}\))\s*\->\s*'
+    - match: '(\({{ident}}\))\s*(\->)\s*'
       captures:
         0: meta.function.anonymous.pkl
         1: variable.other.pkl
-
-  classPattern:
-    - match: '(?:(open)\s+)?(class)\s+({{ident}})(?:\s*(extends)\s+({{ident}}))?'
-      captures:
-        0: meta.class.pkl
-        1: storage.modifier.pkl keyword.other.pkl
-        2: storage.type.class.pkl keyword.declaration.class.pkl
-        3: entity.name.class.pkl
-        4: storage.modifier.pkl keyword.other.pkl
-        5: entity.name.type.pkl
-
-  newPattern:
-    - match: '\b(new)\s+({{ident}})?'
-      captures:
-        1: keyword.pkl
-        2: entity.name.type.pkl
+        2: keyword.operator.pkl
 
   isPattern:
     - match: '(`?)({{ident}})(`?)\s+(is)\s+'
@@ -414,3 +402,12 @@ contexts:
           scope: punctuation.section.brackets.end.pkl
           set: after-expression
         - include: main
+    - match: '\{'
+      scope: punctuation.section.block.begin.pkl
+      push:
+        - meta_content_scope: meta.block.pkl
+        - match: '\}'
+          scope: punctuation.section.block.end.pkl
+          set: after-expression
+        - include: main
+

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -52,11 +52,14 @@ contexts:
     - match: \*/
       scope: invalid.illegal.pkl
 
-
-
-  escape_captures:
-    - match: \\.
+  escaped-char:
+    - match: '\\[\\"''tnr]'
       scope: constant.character.escape.pkl
+
+  escaped-unicode-char:
+    - match: '\\u\{\h{1,6}\}'
+      scope: constant.character.escape.unicode.pkl
+
 
   string-interpolation:
     - match: \\\(
@@ -73,11 +76,12 @@ contexts:
       scope: string.quoted.double.pkl punctuation.definition.string.begin.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.double.pkl
-        - include: string-interpolation
-        - include: escape_captures
         - match: '"'
           scope: punctuation.definition.string.end.pkl
           pop: true
+        - include: string-interpolation
+        - include: escaped-char
+        - include: escaped-unicode-char
 
   string-block:
     - match: '"""'
@@ -88,7 +92,8 @@ contexts:
           scope: punctuation.definition.string.end.pkl
           pop: true
         - include: string-interpolation
-        - include: escape_captures
+        - include: escaped-char
+        - include: escaped-unicode-char
 
 
   string-quoted:
@@ -101,6 +106,7 @@ contexts:
           pop: true
         - include: string-interpolation
         - include: escape_captures
+        - include: escaped-unicode-char
 
   all:
     - match: ([_\w]+)\s*([=:{])

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -3,27 +3,29 @@
 # Syntax: sublimetext.com/docs/syntax.html
 
 name: Pkl
-file_extensions:
-  - pkl
-  - pcf
+file_extensions: [pkl, pcf]
 scope: source.pkl
 
 contexts:
   main:
-    - include: comment-single-line
-    - include: comment-multi-line
+    - include: comments
+    - include: string-quoted-single
     - include: string-double
+    - include: string-block
     - include: keyword
     - include: class
     - include: literal
     - include: number
     - include: built-in
-    - include: string-quoted
     - include: super
     - include: type
     - include: operator
     - include: method
     - include: all
+
+  comments:
+    - include: comment-single-line
+    - include: comment-multi-line
 
   comment-single-line:
     - match: //
@@ -50,33 +52,49 @@ contexts:
     - match: \*/
       scope: invalid.illegal.pkl
 
+
+
+  escape_captures:
+    - match: \\.
+      scope: constant.character.escape.pkl
+
+  string-interpolation:
+    - match: \\\(
+      push:
+        - clear_scopes: 1
+        - meta_scope: meta.interpolation.pkl
+        - match: \)
+          scope: punctuation.section.interpolation.end.pkl
+          pop: true
+        - include: main
+
   string-double:
     - match: '"'
-      scope: punctuation.definition.string.begin.pkl
+      scope: string.quoted.double.pkl punctuation.definition.string.begin.pkl
       push:
-        - include: variable-string
-        - include: number
-        - meta_scope: string.quoted.double.pkl
-        - match: \\.
-          scope: constant.character.escape.pkl
+        - meta_content_scope: meta.string.pkl string.quoted.double.pkl
+        - include: string-interpolation
+        - include: escape_captures
         - match: '"'
           scope: punctuation.definition.string.end.pkl
           pop: true
 
+  # string-block:
+  #   - match: '"""'
+  #     scope: string.quoted.triple.pkl punctuation.definition.string.begin.pkl
+  #     push:
+
+
   string-quoted:
     - match: \`
-      scope: punctuation.definition.string.begin.pkl
+      scope: string.quoted.single.pkl punctuation.definition.string.begin.pkl
       push:
-        - meta_scope: string.quoted.double.pkl
-        - match: \\.
-          scope: constant.character.escape.pkl
+        - meta_content_scope: meta.string.pkl string.quoted.single.pkl
         - match: \`
           scope: punctuation.definition.string.end.pkl
           pop: true
-
-  variable-string:
-    - match: (\\\()([\w.])*(\))
-      scope: constant.variable.pkl
+        - include: string-interpolation
+        - include: escape_captures
 
   all:
     - match: ([_\w]+)\s*([=:{])
@@ -88,8 +106,12 @@ contexts:
   number:
     - match: (?:(?:[-]?)(?:[0-9e]*)(?:\.{1}){1}(?:[0-9e]+))
       scope: constant.numeric.float.decimal.pkl
-    - match: \b(?:0[xXbBoO])(?:[_0-9a-fA-F]+)
+    - match: \b(?:0[xX])(?:[_0-9a-fA-F]+)
       scope: constant.numeric.hex.pkl
+    - match: \b(?:0[bB])(?:[_0-9a-fA-F]+)
+      scope: constant.numeric.binary.pkl
+    - match: \b(?:0[oO])(?:[_0-9a-fA-F]+)
+      scope: constant.numeric.octal.pkl
     - match: \b(?:[-]?)(?:[0-9_]+)
       scope: constant.numeric.integer.decimal.pkl
 
@@ -106,6 +128,8 @@ contexts:
       scope: keyword.operator.logical
     - match: '[~&|^]|<<|>>>?'
       scope: keyword.operator.bitwise
+    - match: '==|<|>|<=|>='
+      scope: keyword.operator.comparison
 
   punctuation:
     - match: \.

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -32,7 +32,6 @@ variables:
 contexts:
   main:
     - include: typealias
-    - include: forPattern
     - include: isPattern
     - include: functions
     - include: lambda-function
@@ -337,14 +336,14 @@ contexts:
         3: keyword.operator.assignment.pkl
         4: entity.name.type.pkl
 
-  forPattern:
-    - match: '\b(for)\s*\(({{ident}})(?:\s*,\s*({{ident}}))*\s+(in)'
-      captures:
-        0: meta.block.for.pkl
-        1: keyword.control.loop.for.pkl
-        2: variable.other.property.pkl
-        3: variable.other.property.pkl
-        4: storage.modifier.pkl
+  # forPattern:
+  #   - match: '\b(for)\s*\(({{ident}})(?:\s*,\s*({{ident}}))*\s+(in)\s+({{ident}})\)'
+  #     captures:
+  #       1: keyword.control.loop.for.pkl
+  #       2: variable.other.pkl
+  #       3: variable.other.pkl
+  #       4: keyword.pkl
+  #       5: variable.other.pkl
 
   functions:
     - match: '\b(function)\s+({{ident}})'

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -79,15 +79,21 @@ contexts:
           scope: punctuation.definition.string.end.pkl
           pop: true
 
-  # string-block:
-  #   - match: '"""'
-  #     scope: string.quoted.triple.pkl punctuation.definition.string.begin.pkl
-  #     push:
+  string-block:
+    - match: '"""'
+      scope: string.quoted.triple.pkl punctuation.definition.string.begin.pkl
+      push:
+        - meta_content_scope: meta.string.pkl string.quoted.triple.pkl
+        - match: '"""'
+          scope: punctuation.definition.string.end.pkl
+          pop: true
+        - include: string-interpolation
+        - include: escape_captures
 
 
   string-quoted:
     - match: \`
-      scope: string.quoted.single.pkl punctuation.definition.string.begin.pkl
+      scope:  meta.string.pkl string.quoted.single.pkl punctuation.definition.string.begin.pkl
       push:
         - meta_content_scope: meta.string.pkl string.quoted.single.pkl
         - match: \`

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -33,6 +33,7 @@ contexts:
   main:
     - include: typealias
     - include: isPattern
+    - include: asPattern
     - include: functions
     - include: lambda-function
     - include: class-declaration
@@ -408,12 +409,15 @@ contexts:
         2: keyword.operator.pkl
 
   isPattern:
-    - match: '(`?)({{ident}})(`?)\s+(is)\s+'
+    - match: '({{ident}})\s+(is)\s+'
       captures:
-        1: punctuation.section.quoted.begin.pkl
-        2: variable.other.pkl
-        3: punctuation.section.quoted.end.pkl
-        4: keyword.pkl
+        1: variable.other.pkl
+        2: keyword.pkl
+      push: type
+
+  asPattern:
+    - match: '(as)\s+'
+      scope: keyword.pkl
       push: type
 
   member-predicate:

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -12,18 +12,16 @@ variables:
   octets: '(?:[0-7][0-7_]*[0-7]|[0-7])'
   hexa: '(?:[\da-fA-F][\da-fA-F_]*[\da-fA-F]|[\da-fA-F_])'
 
-  variable: '(?:[\p{L}_$][\p{L}0-9_$]*)' # can't start with a number
-  # baseType: '(?:{{variable}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
-  baseType: '(?:\*?{{variable}}\s*(?:<[^>]*>)?)' # eg: Listing<Mapping>(something)?
+  ident: '(?:[\p{L}_$][\p{L}0-9_$]*\b)' # can't start with a number
+  # baseType: '(?:{{ident}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
+  baseType: '(?:\*?{{ident}}\s*(?:<[^>]*>)?)' # eg: Listing<Mapping>
   type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*)' # eg: Listing<Float>|Mapping<Int>?|Duration
 
 contexts:
   main:
     - include: module
     - include: typealias
-    - include: variableDecl
-    - include: variableDeclType
-    - include: genericTypeMatch
+    - include: type-decl
     - include: forPattern
     - include: newPattern
     - include: functions
@@ -35,18 +33,13 @@ contexts:
     - include: literal
     - include: number
     - include: super
-    - include: type
     - include: operator
+    - include: quoted-identifiers
+    - include: identifiers
 
   comments:
-    - include: comment-single-line
-    - include: comment-multi-line
-
-  comment-single-line:
     - match: //.*
       scope: comment.line.pkl
-
-  comment-multi-line:
     - match: '/\*'
       scope: punctuation.definition.comment.begin.pkl
       push:
@@ -54,10 +47,7 @@ contexts:
         - match: '\*/'
           scope: punctuation.definition.comment.end.pkl
           pop: true
-    - include: comment-error
-
-  comment-error:
-    - match: \*/
+    - match: '\*/'
       scope: invalid.illegal.pkl
 
   escaped-char:
@@ -100,7 +90,6 @@ contexts:
         - include: escaped-char
 
   strings:
-    - include: string-quoted
     - include: string-multi-line-2
     - include: string-single-line-2
     - include: string-multi-line-1
@@ -168,30 +157,20 @@ contexts:
           pop: true
         - include: escape-char-2
 
-  string-quoted:
-    - match: \`
-      scope:  meta.string.pkl string.quoted.single.pkl punctuation.definition.string.begin.pkl
-      push:
-        - meta_content_scope: meta.string.pkl string.quoted.single.pkl
-        - match: \`
-          scope: punctuation.definition.string.end.pkl
-          pop: true
-        - include: escape-char-0
-
   number:
-    - match: '(?:{{digits}}?\.{{digits}}(?:[eE][+-]?{{digits}})?|{{digits}}[eE][+-]?{{digits}})'
+    - match: '\b(?:{{digits}}?\.{{digits}}(?:[eE][+-]?{{digits}})?|{{digits}}[eE][+-]?{{digits}})\b'
       scope: constant.numeric.float.pkl
-    - match: '(?:0[xX]){{hexa}}'
+    - match: '\b(?:0[xX]){{hexa}}\b'
       scope: constant.numeric.integer.hex.pkl
-    - match: '(?:0[bB]){{bits}}'
+    - match: '\b(?:0[bB]){{bits}}\b'
       scope: constant.numeric.integer.binary.pkl
-    - match: '(?:0[oO]){{octets}}'
+    - match: '\b(?:0[oO]){{octets}}\b'
       scope: constant.numeric.integer.octal.pkl
-    - match: '{{digits}}'
+    - match: '\b{{digits}}\b'
       scope: constant.numeric.integer.decimal.pkl
 
   operator:
-    - match: '\|>|\?\?|!!|\->|\|'
+    - match: '\|>|\?\.|\?\?|!!|\->|\|'
       scope: keyword.operator.pkl
     - match: '(==|!=|<=|>=|>|<)'
       scope: keyword.operator.comparison
@@ -205,7 +184,7 @@ contexts:
       scope: keyword.operator.logical
 
   punctuation:
-    - match: '\.\b'
+    - match: '\b\.\b'
       scope: punctuation.accessor
     - match: \,
       scope: punctuation.separator.comma.pkl
@@ -235,16 +214,81 @@ contexts:
       scope: constant.language.infinity.pkl
 
   super:
-    - match: \@({{variable}})
+    - match: \@({{ident}})
       scope: keyword.pkl
 
+  identifiers:
+    - match: '({{ident}})\s*(?=`?{)'
+      scope: variable.object.pkl
+      push: after-expression
+    - match: '({{ident}})\s*(?=`?=\s*(?:new|\([^)]+\)\s*{))'
+      scope: variable.object.pkl
+      push: after-expression
+    - match: '({{ident}})\s*(?=`?=)'
+      scope: variable.property.pkl
+      push: after-expression
+    - match: '{{ident}}'
+      scope: meta.identifier.pkl
+      push: after-expression
+
+  quoted-identifiers:
+    - match: '`'
+      scope: punctuation.section.quoted.begin.pkl
+      push:
+        - meta_content_scope: meta.quoted.pkl
+        - match: '`'
+          scope: punctuation.section.quoted.end.pkl
+          pop: true
+        - include: identifiers
+
   type:
-    - match: \b(Int|String|Boolean|Float|Number|Any|Base)\b
+    - match: \b(\*?(?:Pair|Collection|List|Set|Map|Listing|Mapping))\b
+      scope: support.type.pkl
+      push: generic-angles
+    - match: \b(\*?(?:U?Int(?:8|16|32)?|String|Uri|Boolean|Float|Number|Any|Base))\b
       scope: storage.type.pkl
-    - match: \b(UInt16|UInt8|UInt)\b
-      scope: storage.type.pkl
-    - match: \b(Collection|List|Set|Map|Listing|Mapping)\b
-      scope: entity.name.type.pkl
+    - match: '\*?{{ident}}\b'
+      scope: support.type.pkl
+    - match: '\|'
+      scope: punctuation.separator.sequence.pkl
+
+  type-constraint:
+    - meta_content_scope: meta.type.constraint.pkl
+    - match: '\)'
+      scope: punctuation.section.parens.end.pkl
+      pop: true
+    - match: '\('
+      scope: punctuation.section.parens.begin.pkl
+      push: type-constraint-contents
+    - match: '\s*(?=\S)'
+      pop: true
+
+  type-constraint-contents:
+    - meta_content_scope: meta.type.constraint.pkl
+    - match: '\)'
+      scope: punctuation.section.parens.end.pkl
+      set: main
+
+
+  generic-angles:
+    - meta_content_scope: meta.generic.pkl
+    - match: '>'
+      scope: punctuation.definition.generic.end.pkl
+      pop: true
+    - match: '<'
+      scope: punctuation.definition.generic.begin.pkl
+      push: generic-angles-contents
+    - match: ','
+      scope: punctuation.separator.pkl
+      pop: true
+    - match: '\|'
+      scope: punctuation.separator.sequence.pkl
+    - match: '\s*(?=\S)'
+      pop: true
+
+  generic-angles-contents:
+    - include: type
+    - include: generic-angles
 
   keyword:
     - match: \b(|protected|override|record|delete|match|case|vararg|const)\b
@@ -263,14 +307,14 @@ contexts:
       scope: variable.language.pkl
 
   module:
-    - match: '(?:(module)\s+({{variable}}(?:\.{{variable}}))?)'
+    - match: '(?:(module)\s+({{ident}}(?:\.{{ident}}))?)'
       captures:
         0: meta.module.pkl
         1: variable.language.pkl
         2: variable.other.module.pkl
 
   typealias:
-    - match: '(typealias)\s+({{variable}})\s*(=)\s*({{type}})'
+    - match: '(typealias)\s+({{ident}})\s*(=)\s*({{type}})'
       captures:
         0: meta.typealias.pkl
         1: keyword.declaration.class.pkl
@@ -278,30 +322,8 @@ contexts:
         3: keyword.operator.assignment.pkl
         4: entity.name.type.pkl
 
-  variableDecl:
-    - match: '(\b{{variable}}|`[^`]+`)\s*(?:(=)(?!=)|(?={))'
-      captures:
-        0: meta.variable.declaration.pkl
-        1: variable.other.property.pkl
-        2: keyword.operator.assignment.pkl
-
-  variableDeclType:
-    - match: '(\b{{variable}}|`[^`]+`)\s*(:)\s*({{type}})'
-      captures:
-        0: meta.variable.declaration.pkl
-        1: variable.other.property.pkl
-        2: punctuation.separator.pkl
-        3: entity.name.type.pkl
-
-  genericTypeMatch:
-    - match: '(:)\s*({{type}})'
-      captures:
-        0: meta.annotation.identifier.pkl
-        1: punctuation.separator.pkl
-        2: entity.name.type.pkl
-
   forPattern:
-    - match: '\b(for)\s*\(({{variable}})(?:\s*,\s*({{variable}}))*\s+(in)'
+    - match: '\b(for)\s*\(({{ident}})(?:\s*,\s*({{ident}}))*\s+(in)'
       captures:
         0: meta.block.for.pkl
         1: keyword.control.loop.for.pkl
@@ -310,20 +332,20 @@ contexts:
         4: storage.modifier.pkl
 
   functions:
-    - match: '\b(function)\s+({{variable}})'
+    - match: '\b(function)\s+({{ident}})'
       captures:
         0: meta.function.pkl
         1: keyword.pkl
         2: entity.name.function.pkl
 
   lambda-function:
-    - match: '(\({{variable}}\))\s*\->\s*'
+    - match: '(\({{ident}}\))\s*\->\s*'
       captures:
         0: meta.function.anonymous.pkl
         1: variable.other.pkl
 
   class:
-    - match: '(open)?(class)\s+(\w+)(?:\s*(extends)\s+(\w+))?'
+    - match: '(?:(open)\s+)?(class)\s+({{ident}})(?:\s*(extends)\s+({{ident}}))?'
       captures:
         0: meta.class.pkl
         1: keyword.other.pkl
@@ -333,7 +355,22 @@ contexts:
         5: support.type.pkl
 
   newPattern:
-    - match: '\b(new)\s+({{variable}})?'
+    - match: '\b(new)\s+({{ident}})?'
       captures:
         1: keyword.pkl
         2: support.type.pkl
+
+  after-expression:
+    - match: (\.)(?={{ident}})
+      scope: punctuation.accessor.dot.pkl
+      push:
+        - match: ''
+          pop: true
+    - match: (\s*:\s*)
+      scope: punctuation.separator.pkl
+      push:
+        - include: type
+        - match: ''
+          pop: true
+    - match: ''
+      pop: true

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -14,22 +14,26 @@ variables:
 
   variable: '(?:[\p{L}_$][\p{L}0-9_$]*)' # can't start with a number
   baseType: '(?:{{variable}}\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*\??)' # eg: Listing<Mapping>(something)?
-  type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*' # eg: Listing<Float>|Mapping<Int>?|Duration
+  type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*)' # eg: Listing<Float>|Mapping<Int>?|Duration
 
 contexts:
   main:
-    - include: comments
+    - include: module
+    - include: typealias
+    - include: variableDecl
+    - include: variableDeclType
+    - include: genericTypeMatch
+    - include: forPattern
+    - include: method
+    - include: class
     - include: strings
     - include: keyword
-    - include: class
     - include: literal
     - include: number
-    - include: built-in
     - include: super
     - include: type
     - include: operator
-    - include: method
-    - include: all
+    - include: comments
 
   comments:
     - include: comment-single-line
@@ -59,7 +63,7 @@ contexts:
       pop: true
 
   escaped-unicode-char:
-    - match: 'u\{\h{1,6}\}'
+    - match: 'u\{[\da-fA-F]{1,6}\}'
       scope: constant.character.escape.unicode.pkl
       pop: true
 
@@ -175,12 +179,6 @@ contexts:
           pop: true
         - include: escape-char-0
 
-  all:
-    - match: ([_\w]+)\s*(?=[=:{])
-      captures:
-        0: meta.pkl
-        1: variable.pkl
-
   number:
     - match: '
       \b(?:
@@ -198,10 +196,6 @@ contexts:
       scope: constant.numeric.integer.octal.pkl
     - match: \b{{digits}}
       scope: constant.numeric.integer.decimal.pkl
-
-  built-in:
-    - match: \b(JsonRenderer|YamlRenderer)\b
-      scope: support.class.pkl
 
   operator:
     - match: '\|>|\?\?|!!|\->|\|'
@@ -248,7 +242,7 @@ contexts:
       scope: constant.language.infinity.pkl
 
   super:
-    - match: \@(\w+)
+    - match: \@({{variable}})
       scope: keyword.pkl
 
   type:
@@ -258,29 +252,72 @@ contexts:
       scope: storage.type.pkl
 
   keyword:
-    - match: \b(let|function|protected|override|record|delete|match|vararg)\b
+    - match: \b(|protected|override|record|delete|match|case|vararg|const)\b
+      scope: keyword.other.pkl
+    - match: '\b(amends|as|extends|function|is|let|read|read\\?|import|import\*|throw|trace)\b'
       scope: keyword.pkl
-    - match: \b(if|else|for|when|switch|case)\b
+    - match: \b(if|else|for|when)\b
       scope: keyword.control.conditional.pkl
-    - match: \b(import|new)\b
-      scope: keyword.control.import.pkl
-    - match: \b(is|as|in)\b
-      scope: keyword.import.from.pkl
     - match: \b(hidden|local|abstract|external|open|in|out|amends|extends|fixed)\b
       scope: storage.modifier.pkl
     - match: \b(class|typealias)\b
       scope: keyword.declaration.class.pkl
     - match: \b(this|module|outer|super)\b
-      scope: variable.language.pkl
+      scope: variable.language.pkl keyword.pkl
 
+  module:
+    - match: '(?:(module)\s+({{variable}}(?:\.{{variable}}))?)'
+      captures:
+        0: meta.module.pkl
+        1: variable.language.pkl
+        2: variable.other.module.pkl
+
+  typealias:
+    - match: '(typealias)\s+({{variable}})\s*(=)\s*({{type}})'
+      captures:
+        0: meta.typealias.pkl
+        1: keyword.declaration.class.pkl
+        2: entity.name.type.pkl
+        3: keyword.operator.assignment.pkl
+        4: entity.name.type.pkl
+
+  variableDecl:
+    - match: '(\b{{variable}}|`[^`]+`)\s*(=)(?!=)'
+      captures:
+        0: meta.variable.declaration.pkl
+        1: variable.other.property.pkl
+        2: keyword.operator.assignment.pkl
+
+  variableDeclType:
+    - match: '(\b{{variable}}|`[^`]+`)\s*(:)\s*({{type}})'
+      captures:
+        0: meta.variable.declaration.pkl
+        1: variable.other.property.pkl
+        2: punctuation.separator.pkl
+        3: entity.name.type.pkl
+
+  genericTypeMatch:
+    - match: '(:)\s*({{type}})'
+      captures:
+        0: meta.annotation.identifier.pkl
+        1: punctuation.separator.pkl
+        2: entity.name.type.pkl
+
+  forPattern:
+    - match: '\b(for)\s*\(({{variable}})(?:\s*,\s*({{variable}}))*\s+(in)'
+      captures:
+        0: meta.block.for.pkl
+        1: keyword.control.loop.for.pkl
+        2: variable.other.property.pkl
+        3: variable.other.property.pkl
+        4: storage.modifier.pkl
   method:
-    - match: '^(?:(const|))(?:(function|))\s+([A-Za-z0-9]{1,}(\(\)){1})'
+    - match: '\b(function)\s+({{variable}})\(([^)]*)\)'
       captures:
         0: meta.function.pkl
-        1: storage.modifier.pkl
-        2: keyword.pkl
-        3: entity.name.function.pkl
-        4: punctuation.section.parens.begin.pkl
+        1: keyword.pkl
+        2: entity.name.function.pkl
+        3: meta.function.parameters.pkl
 
   class:
     - match: '^(?:(open|))\s*(class)?\s+([A-Za-z0-9]{1,})(?:\s*(extends|))(?:\s*([A-Za-z0-9]{1,}|)):?$\n?'
@@ -291,3 +328,9 @@ contexts:
         3: support.class.pkl
         4: keyword
         5: support.class.pkl
+
+# TODO:
+#   -better matching for union types
+#   -Type constraints not marked as type?
+#   -class declaration patter matcher
+#   -lambda pattern matcher

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -368,6 +368,37 @@ contexts:
         0: meta.function.pkl
         1: keyword.pkl
         2: entity.name.function.pkl
+      push: function-proto
+
+  function-proto:
+    - match: \(
+      scope: punctuation.section.parens.begin.pkl
+      push:
+        - meta_content_scope: meta.function.parameters.pkl
+        - match: \)
+          scope: punctuation.section.parens.end.pkl
+          pop: true
+          set: after-expression
+        - include: main
+    - match: '='
+      scope: keyword.operator.assignment.pkl
+      set: function-body
+
+  function-body:
+    - meta_content_scope: meta.function.pkl
+    - match: '\n'
+      pop: true
+    - match: '\b(new)\s+(\{)'
+      captures:
+        1: keyword.pkl
+        2: punctuation.section.function.begin.pkl
+      push:
+      - match: '\}'
+        scope: punctuation.section.function.end.pkl
+        pop: true
+        set: after-expression
+      - include: main
+    - include: main
 
   lambda-function:
     - match: '(\({{ident}}\))\s*(\->)\s*'

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -254,6 +254,7 @@ contexts:
         - match: '{{ident}}'
           scope: variable.other.key.pkl
         - include: strings
+        - include: constants
     - match: '{{ident}}\s*(?==)'
       scope: variable.other.property.pkl
     - match: '{{ident}}\s*(?={)'

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -17,6 +17,15 @@ variables:
   baseType: '(?:\*?{{ident}}\s*(?:<[^>]*>)?)' # eg: Listing<Mapping>
   type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*)' # eg: Listing<Float>|Mapping<Int>?|Duration
 
+  stdlib_bas: |-
+    (?x:  # WIP
+      Regex|Undefined|TODO|IntSeq|getClass|toString|ifNonNull
+      |hasProperty|getProperty|toDynamic|toMap|relativePathTo
+      |xor|implies
+    )
+
+  duration_unit: (?:ns|us|ms|s|min|h|d)
+  data_size_unit: (?:b|kb|kib|mb|mib|gb|gib|tb|tib|pb|pib)
 contexts:
   main:
     - include: typealias
@@ -25,7 +34,7 @@ contexts:
     - include: isPattern
     - include: functions
     - include: lambda-function
-    - include: class
+    - include: classPattern
     - include: comments
     - include: strings
     - include: keyword
@@ -161,14 +170,19 @@ contexts:
   number:
     - match: '\b(?:{{digits}}?\.{{digits}}(?:[eE][+-]?{{digits}})?|{{digits}}[eE][+-]?{{digits}})\b'
       scope: constant.numeric.float.pkl
+      push: after-expression
     - match: '\b(?:0[xX]){{hexa}}\b'
       scope: constant.numeric.integer.hex.pkl
+      push: after-expression
     - match: '\b(?:0[bB]){{bits}}\b'
       scope: constant.numeric.integer.binary.pkl
+      push: after-expression
     - match: '\b(?:0[oO]){{octets}}\b'
       scope: constant.numeric.integer.octal.pkl
+      push: after-expression
     - match: '\b{{digits}}\b'
       scope: constant.numeric.integer.decimal.pkl
+      push: after-expression
 
   literal:
     - match: \b(true|false)\b
@@ -195,7 +209,7 @@ contexts:
       scope: keyword.operator.logical
 
   keyword:
-    - match: \b(|protected|override|record|delete|match|case|vararg|const)\b
+    - match: \b(protected|override|record|delete|match|case|vararg|const)\b
       scope: keyword.other.pkl
     - match: '\b(read\?|read\*|read|import\*)\b?'
       scope: keyword.import.pkl
@@ -259,14 +273,14 @@ contexts:
         - include: identifiers
 
   type:
-    - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping)\b
+    - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping|Dynamic)\b
       scope: storage.type.pkl
       push:
         - match: '(?=<)'
           push: generic-angles
         - match: ''
           pop: true
-    - match: \b(U?Int(?:8|16|32)?|String|Uri|Boolean|Float|Number)\b
+    - match: \b(U?Int(?:8|16|32)?|String|Uri|Char|Comparable|Boolean|Float|Number)\b
       scope: storage.type.pkl
     - match: \b(Any|nothing)\b
       scope: storage.type.class.pkl
@@ -342,7 +356,7 @@ contexts:
         0: meta.function.anonymous.pkl
         1: variable.other.pkl
 
-  class:
+  classPattern:
     - match: '(?:(open)\s+)?(class)\s+({{ident}})(?:\s*(extends)\s+({{ident}}))?'
       captures:
         0: meta.class.pkl
@@ -371,6 +385,12 @@ contexts:
     - match: (\.)(?={{ident}})
       scope: punctuation.accessor.dot.pkl
       push:
+        - match: '{{duration_unit}}'
+          scope: support.type.duration.pkl
+          push: after-expression
+        - match: '{{data_size_unit}}'
+          scope: support.type.data_size.pkl
+          push: after-expression
         - match: ''
           pop: true
     - match: \s*(:)\s*

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -11,7 +11,6 @@ variables:
 contexts:
   main:
     - include: comments
-    - include: custom-string-1
     - include: strings
     - include: keyword
     - include: class
@@ -29,26 +28,18 @@ contexts:
     - include: comment-multi-line
 
   comment-single-line:
-    - match: //
-      scope: punctuation.definition.comment.pkl
-      push:
-        - meta_scope: comment.line.pkl
-        - match: $\n?
-          pop: true
+    - match: //.*
+      scope: comment.line.pkl
 
   comment-multi-line:
-    - match: /\*
+    - match: '/\*'
       scope: punctuation.definition.comment.begin.pkl
       push:
-        - meta_scope: comment.block.pkl
-        - match: \*/
+        - meta_content_scope: comment.block.pkl
+        - match: '\*/'
           scope: punctuation.definition.comment.end.pkl
           pop: true
-        - match: '^\s*(\*)(?!/)'
-          captures:
-            0: punctuation.definition.comment.pkl
     - include: comment-error
-
   comment-error:
     - match: \*/
       scope: invalid.illegal.pkl
@@ -128,14 +119,14 @@ contexts:
         - include: escape-char-1
 
   string-single-line-2:
-  - match: '##"'
-    scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
-    push:
-      - meta_content_scope: meta.string.pkl string.quoted.double.2.pkl
-      - match: '"##'
-        scope: punctuation.definition.string.end.2.pkl
-        pop: true
-      - include: escape-char-2
+    - match: '##"'
+      scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
+      push:
+        - meta_content_scope: meta.string.pkl string.quoted.double.2.pkl
+        - match: '"##'
+          scope: punctuation.definition.string.end.2.pkl
+          pop: true
+        - include: escape-char-2
 
   string-multi-line-0:
     - match: '(""")\s*?$' # content must start on a new line
@@ -243,7 +234,11 @@ contexts:
     - match: \b(true|false)\b
       scope: constant.language.boolean.pkl
     - match: \b(null)\b
+      scope: constant.language.null.pkl
+    - match: \b(NaN)\b
       scope: constant.language.nan.pkl
+    - match: \b(Infinity)\b
+      scope: constant.language.infinity.pkl
 
   super:
     - match: \@(\w+)

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -172,7 +172,6 @@ contexts:
       captures:
         0: meta.pkl
         1: variable.pkl
-        2: keyword.operator.assignment
 
   number:
     - match: (?:(?:[-]?)(?:[0-9e]*)(?:\.{1}){1}(?:[0-9e]+))
@@ -191,16 +190,18 @@ contexts:
       scope: support.class.pkl
 
   operator:
-    - match: '(==|<|>|<=|>=)'
+    - match: '\|>|\?\?|!!|\->|\|'
+      scope: keyword.operator.pkl
+    - match: '(==|!=|<=|>=|>|<)'
       scope: keyword.operator.comparison
-    - match: '([+*/%-:&|^]|<<|>>>?)='
+    - match: '='
       scope: keyword.operator.assignment
-    - match: '[+*/%-]'
+    - match: '(\*\*|[+\-*\/%]|~\/)'
       scope: keyword.operator.arithmetic
-    - match: '\!|\&\&|\|\|'
-      scope: keyword.operator.logical
     - match: '[~&|^]|<<|>>>?'
       scope: keyword.operator.bitwise
+    - match: '\!|\&\&|\|\|'
+      scope: keyword.operator.logical
 
   punctuation:
     - match: \.


### PR DESCRIPTION
Hello,

I've been working more on the syntax in these days, adding some more support to the basic elements of the language.
Main additions and changes:
- made number matching more solid
- rearranged some scopes for keywords and operators
- added some basic language pattern matching (for, as, class, lambdas, functions and others)
- added support to custom strings (`#" \\\ """ "#`) and correctly matching escaping and interpolations within
- Complete Types matching
- property vs object matching

There are still many more things to do and some immediate fixes to be done (like better variable declaration matching) but it is a good amout for a first PR! I'll keep adding modifications to this PR in the mean time

Also, deciding scopes is very hard and what might look ok on my color-scheme might look wrong on yours. Let me know.

PS: I am available to help mantain this package is needed :)