### PR TITLE
Added Base Module symbols highlighting support

### DIFF
--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -16,6 +16,12 @@ num3 = 0b00010111
 num4 = 0o755 
 
 
+const1 = math.e
+const2 = math.minInt
+const3 = math.pi
+const4 = math.maxUInt
+
+
 num1 = 1_000_000 
 num2 = 0x0134_64DE 
 num3 = 0b0001_0111 
@@ -261,6 +267,13 @@ pigeon = new Bird {
   lifespan = 8
 }
 
+pidgeon = new Int {}
+
+// error, can't isntantiate abstract or external classes }
+
+pidgeon = new Mixin {}
+
+
 pigeonInIndex = pigeon.nameAndLifespanInIndex 
 
 pigeonDynamic = pigeon.toDynamic() 
@@ -313,6 +326,9 @@ class Parrot extends Pigeon {
 
   function say() = "Pkl is great!"   
 }
+
+// Can't extend non open classes
+class Test extends Deprecated {} //error
 
 module parrot
 
@@ -383,7 +399,7 @@ quota {
 output {
   renderer = new YamlRenderer {
     converters {
-      [DataSize] = (size) -> "\(size.value) \(size.unit)"
+      [DataSize] = (size) -> "\(size.value) asdsa \(size.unit)"
     }
   }
 }
@@ -518,7 +534,14 @@ birds {
   new { name = "Pigeon" }
   new { name = "Barn owl" }
 }
-names = birds.toList().map((it) -> it.name) as List<String>
+names = birds.toList().map((it: Int) -> it.name) as List<String>
+intnames = bird.toList().map((it: Int) -> getInt() + 3 + "i want to break free".toInt() )
+
+big_anon = (i: Int, j: String) -> new Dynamic {
+  result: String = j*i
+}.appy(3, "a")
+
+big_anon.apply(3, "a")
 
 class Bird {
   name: String 
@@ -676,6 +699,7 @@ class `class` {
 /// An adult [Bird].
 typealias Adult = Bird(lifespan >= 2)
 
+typealias StrangeString = String|Int
 /// A common [Bird] found in large cities.
 pigeon: Bird = new {
   name = "Pigeon"

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -700,6 +700,9 @@ class `class` {
 typealias Adult = Bird(lifespan >= 2)
 
 typealias StrangeString = String|Int
+
+typealias StringLiteral = "this"|"is"|"a"|"string"|"litteral"
+
 /// A common [Bird] found in large cities.
 pigeon: Bird = new {
   name = "Pigeon"
@@ -707,7 +710,7 @@ pigeon: Bird = new {
 }
 
 /// Creates a [Bird] with the given [_name] and lifespan `0`.
-function Infant(_name: String): Bird = new { name = _name; lifespan = 0 }
+function Infant(_name: String): Bird|String|Listing<Bird, Duration> = new { name = _name; lifespan = 0 }
 
 @Unlisted
 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -539,13 +539,13 @@ intnames = bird.toList().map((it: Int) -> getInt() + 3 + "i want to break free".
 
 big_anon = (i: Int, j: String) -> new Dynamic {
   result: String = j*i
-}.appy(3, "a")
+}.apply(3, "a")
 
 big_anon.apply(3, "a")
 
 class Bird {
   name: String 
-}
+}.toTyped
 bird: Bird
 
 

--- a/example/syntax_test.pkl
+++ b/example/syntax_test.pkl
@@ -258,7 +258,7 @@ pigeon = new Dynamic {
 class Bird {
   name: String
   lifespan: Int
-  hidden nameAndLifespanInIndex = "\(name), \(lifespan)" 
+  hidden nameAndLifespanInIndex = "\(name), \(1), \(lifespan)"
   nameSignWidth: UInt = nameAndLifespanInIndex.length 
 }
 

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -117,7 +117,7 @@ contexts:
         - meta_content_scope: string.quoted.double.0.pkl
         - match: '"'
           scope: string.quoted.double.0.pkl punctuation.definition.string.end.0.pkl
-          pop: true
+          set: after-expression
         - include: escape-char-0
 
   string-single-line-1:
@@ -127,7 +127,7 @@ contexts:
         - meta_content_scope: string.quoted.double.1.pkl
         - match: '"#'
           scope: string.quoted.double.1.pkl punctuation.definition.string.end.1.pkl
-          pop: true
+          set: after-expression
         - include: escape-char-1
 
   string-single-line-2:
@@ -137,7 +137,7 @@ contexts:
         - meta_content_scope: string.quoted.double.2.pkl
         - match: '"##'
           scope: string.quoted.double.2.pkl punctuation.definition.string.end.2.pkl
-          pop: true
+          set: after-expression
         - include: escape-char-2
 
   string-multi-line-0:
@@ -147,7 +147,7 @@ contexts:
         - meta_content_scope: string.quoted.triple.0.pkl
         - match: '^\s*?(""")' # closing delim must start on a new line
           scope: string.quoted.triple.0.pkl punctuation.definition.string.end.0.pkl
-          pop: true
+          set: after-expression
         - include: escape-char-0
 
   string-multi-line-1:
@@ -157,7 +157,7 @@ contexts:
         - meta_content_scope: string.quoted.triple.1.pkl
         - match: '^\s*?("""#)' # closing delim must start on a new line
           scope: string.quoted.triple.1.pkl punctuation.definition.string.end.1.pkl
-          pop: true
+          set: after-expression
         - include: escape-char-1
 
   string-multi-line-2:
@@ -167,7 +167,7 @@ contexts:
         - meta_content_scope: string.quoted.triple.2.pkl
         - match: '^\s*?("""##)' # closing delim must start on a new line
           scope: string.quoted.triple.2.pkl punctuation.definition.string.end.2.pkl
-          pop: true
+          set: after-expression
         - include: escape-char-2
 
   constants:

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -21,7 +21,7 @@ variables:
 
   # We let pkl do the heavy lifting
   # import "pkl:base"
-  # import "pkl:reflect"
+  # import "pkl:reflect" // Requires pkl v 0.26+ it's broken before.
   #
   # function getMethods(module_mirror): Set = module_mirror.classes.flatMap((k,v) -> Map(k, v.methods.keys)).fold(Set(), (S, k, v) -> S.add(v)).flatten()
   # function getProperties(module_mirror): Set = module_mirror.classes.flatMap((k,v) -> Map(k, v.properties.keys)).fold(Set(), (S, k, v) -> S.add(v)).flatten()

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -347,30 +347,28 @@ contexts:
     - include: type
 
   typealias:
-    - match: '(typealias)\s+({{ident}})\s*(=)\s*({{type}})'
+    - match: '(typealias)\s+({{ident}})'
       captures:
         0: meta.typealias.pkl
         1: keyword.declaration.class.pkl
         2: entity.name.type.pkl
-        3: keyword.operator.assignment.pkl
-        4: entity.name.type.pkl
+      push: typealias-type
 
-  # forPattern:
-  #   - match: '\b(for)\s*\(({{ident}})(?:\s*,\s*({{ident}}))*\s+(in)\s+({{ident}})\)'
-  #     captures:
-  #       1: keyword.control.loop.for.pkl
-  #       2: variable.other.pkl
-  #       3: variable.other.pkl
-  #       4: keyword.pkl
-  #       5: variable.other.pkl
+  typealias-type:
+    - meta_scope: meta.typealias.pkl
+    - match: '=\s*'
+      scope: keyword.operator.assignment.pkl
+      push: type
+    - match: '(?=\S)'
+      pop: true
 
   functions:
-    - match: '\b(function)\s+({{ident}})'
+    - match: '\b(function)\s+({{ident}})\s*'
       captures:
         0: meta.function.pkl
         1: keyword.pkl
         2: entity.name.function.pkl
-      push: function-proto
+      push: [function-def, function-proto]
 
   function-proto:
     - match: \(

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -284,27 +284,27 @@ contexts:
     - match: '`'
       scope: punctuation.section.quoted.begin.pkl
       push:
-        - meta_content_scope: variable.other.quoted.pkl
+        - meta_content_scope: meta.quoted.pkl
         - match: '`'
           scope: punctuation.section.quoted.end.pkl
           set: after-expression
     - match: '\[(?!\[)'
       scope: punctuation.section.brackets.begin.pkl
       push:
-        - meta_content_scope: variable.other.entry.pkl
+        - meta_content_scope: meta.entry.pkl
         - match: '\]'
           scope: punctuation.section.brackets.end.pkl
           pop: true
         - match: '{{ident}}'
-          scope: variable.other.key.pkl
+          scope: meta.key.pkl
         - include: strings
         - include: constants
     - match: '{{ident}}\s*(?==)'
-      scope: variable.other.property.pkl
+      scope: meta.property.pkl
     - match: '{{ident}}\s*(?={)'
-      scope: variable.other.object.pkl
+      scope: meta.object.pkl
     - match: '{{base_ident}}'
-      scope: variable.other.pkl
+      scope: meta.name.pkl
       push: after-expression
 
   class-declaration:
@@ -522,7 +522,7 @@ contexts:
   isPattern:
     - match: '({{ident}})\s+(is)\s+'
       captures:
-        1: variable.other.pkl
+        1: meta.name.pkl
         2: keyword.pkl
       push: type
 

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -376,6 +376,12 @@ contexts:
       scope: entity.name.type.pkl
     - match: '\s*\|\s*'
       scope: punctuation.separator.sequence.pkl
+    - match: '(?=")'
+      push:
+        - meta_content_scope: meta.type.string-literal.pkl
+        - include: string-single-line-0
+        - match: ''
+          pop: true
     - match: '\*'
       scope: punctuation.definition.annotation.pkl
     - match: '(?=\s*\()'

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -382,18 +382,21 @@ contexts:
           pop: true
           set: after-expression
         - include: main
-    - match: '='
+    - match: '\s*(=)\s*'
       scope: keyword.operator.assignment.pkl
+      pop: true
+
+  function-def:
+    - meta_content_scope: meta.function.pkl
+    - match: '(?=new)'
+      set: [function-body, instantiation]
+    - match: ''
       set: function-body
 
   function-body:
-    - meta_content_scope: meta.function.pkl
-    - match: '\n'
-      pop: true
-    - match: '\b(new)\s+(\{)'
-      captures:
-        1: keyword.pkl
-        2: punctuation.section.function.begin.pkl
+    - meta_content_scope: meta.function.body.pkl
+    - match: '\{'
+      scope: punctuation.section.brackets.begin.pkl
       push:
       - match: '\}'
         scope: punctuation.section.function.end.pkl
@@ -401,13 +404,48 @@ contexts:
         set: after-expression
       - include: main
     - include: main
+    - match: '\n'
+      pop: true
 
   lambda-function:
-    - match: '(\({{ident}}\))\s*(\->)\s*'
-      captures:
-        0: meta.function.anonymous.pkl
-        1: variable.other.pkl
-        2: keyword.operator.pkl
+    - match: '(?=\((?:\s*[^()]\s*\,?)*\)\s*\->)'
+      push: [lambda-func-def, lambda-func-proto]
+
+  lambda-func-proto:
+    - match: '\('
+      scope: punctuation.section.parens.begin.pkl
+      push:
+        - meta_content_scope: meta.function.anonymous.parameters.pkl
+        - match: \)
+          scope: punctuation.section.parens.end.pkl
+          pop: true
+        - include: main
+    - match: '\s*\->\s*'
+      scope: keyword.operator.assignment.pkl
+      pop: true
+
+  lambda-func-def:
+    - meta_content_scope: meta.function.anonymous.pkl
+    - match: '(?=new)'
+      set: [lambda-func-body, instantiation]
+    - match: ''
+      set: lambda-func-body
+
+  lambda-func-body:
+    - meta_content_scope: meta.function.anonymous.body.pkl
+    - match: '\{'
+      scope: punctuation.section.brackets.begin.pkl
+      push:
+      - match: '\}'
+        scope: punctuation.section.function.end.pkl
+        pop: 2
+        set: after-expression
+      - include: main
+    - include: main
+    - match: '\n'
+      pop: true
+    - match: '(?=\S)'
+      pop: true
 
   isPattern:
     - match: '({{ident}})\s+(is)\s+'

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -19,15 +19,45 @@ variables:
   baseType: '(?:\*?{{ident}}\s*(?:<[^>]*>)?)' # eg: Listing<Mapping>
   type: '(?:{{baseType}}\s*(\|\s*{{baseType}})*)' # eg: Listing<Float>|Mapping<Int>?|Duration
 
-  stdlib_bas: |-
-    (?x:  # WIP
-      Regex|Undefined|TODO|IntSeq|getClass|toString|ifNonNull
-      |hasProperty|getProperty|toDynamic|toMap|relativePathTo
-      |xor|implies
-    )
+  # We let pkl do the heavy lifting
+  # import "pkl:base"
+  # import "pkl:reflect"
+  #
+  # function getMethods(module_mirror): Set = module_mirror.classes.flatMap((k,v) -> Map(k, v.methods.keys)).fold(Set(), (S, k, v) -> S.add(v)).flatten()
+  # function getProperties(module_mirror): Set = module_mirror.classes.flatMap((k,v) -> Map(k, v.properties.keys)).fold(Set(), (S, k, v) -> S.add(v)).flatten()
+  #
+  # #"(?:\#(reflect.Module(base).typeAliases.keys.join("|")))"#
+  pklbase_typealiases: '(?:NonNull|Int8|Int16|Int32|UInt8|UInt16|UInt32|UInt|Comparable|Char|Uri|DurationUnit|DataSizeUnit|Mixin)'
 
-  duration_unit: (?:ns|us|ms|s|min|h|d)
-  data_size_unit: (?:b|kb|kib|mb|mib|gb|gib|tb|tib|pb|pib)
+  # #"(?:\#(bm.classes.filter((k,v)->v.modifiers.contains("external")).keys.join("|")))"#
+  pklbase_type_external:  '(?:Any|Null|Class|TypeAlias|Module|Number|Int|Float|Boolean|String|Regex|Duration|DataSize|Object|Function|Function0|Function1|Function2|Function3|Function4|Function5|Pair|Collection|IntSeq|VarArgs|List|Set|Map)'
+  # #"(?:\#(bm.classes.filter((k,v)->v.modifiers.contains("open")).keys.join("|")))"#
+  pklbase_type_open:  '(?:FileOutput)'
+  # #"(?:\#(bm.classes.filter((k,v)->v.modifiers.isEmpty).keys.join("|")))"#
+  pklbase_type_other:  '(?:Since|Deprecated|AlsoKnownAs|Unlisted|DocExample|SourceCode|ModuleInfo|ModuleOutput|PcfRenderer|RenderDirective|PcfRenderDirective|JsonRenderer|YamlRenderer|PListRenderer|PropertiesRenderer|Resource|RegexMatch|Dynamic|Listing|Mapping)'
+  # #"(?:\#(bm.classes.filter((k,v)->v.modifiers.contains("abstract")).keys.join("|")))"#
+  pklbase_type_abstract:  '(?:Any|Module|Annotation|ValueRenderer|Number|Object|Typed|Function|Collection)'
+  pklbase_types: '(?:{{pklbase_type_open}}|{{pklbase_type_abstract}}||{{pklbase_type_external}}||{{pklbase_type_other}})'
+
+  # #"(?:\#(reflect.Module(base).moduleClass.methods.keys.join("|)")))"#
+  pklbase_module_methods: '(?:Regex|Undefined|TODO|Null|Pair|IntSeq|List|Set|Map)'
+  # #"(?:\#(getMethods(reflect.Module(base)).join("|")))"#
+  pklbase_classes_methods: '(?:getClass|toString|ifNonNull|relativePathTo|renderDocument|renderValue|round|truncate|toInt|toFloat|toFixed|toDuration|toDataSize|isBetween|toRadixString|shl|shr|ushr|and|or|xor|toChar|implies|getOrNull|substring|substringOrNull|repeat|contains|matches|startsWith|endsWith|indexOf|indexOfOrNull|lastIndexOf|lastIndexOfOrNull|take|takeWhile|takeLast|takeLastWhile|drop|dropWhile|dropLast|dropLastWhile|replaceFirst|replaceLast|replaceAll|replaceFirstMapped|replaceLastMapped|replaceAllMapped|replaceRange|toUpperCase|toLowerCase|reverse|trim|trimStart|trimEnd|padStart|padEnd|split|capitalize|decapitalize|toIntOrNull|toFloatOrNull|toBoolean|toBooleanOrNull|findMatchesIn|matchEntire|toUnit|toBinaryUnit|toDecimalUnit|hasProperty|getProperty|getPropertyOrNull|toDynamic|toMap|length|toList|toTyped|isDistinctBy|distinctBy|fold|foldIndexed|join|toSet|containsKey|applyToList|apply|splitOrNull|partition|find|findOrNull|findLast|findLastOrNull|findIndex|findIndexOrNull|findLastIndex|findLastIndexOrNull|count|every|any|filter|filterNonNull|filterIndexed|filterIsInstance|map|mapIndexed|mapNonNull|flatMap|flatMapIndexed|flatten|add|foldBack|reduce|reduceOrNull|groupBy|minBy|minByOrNull|minWith|minWithOrNull|maxBy|maxByOrNull|maxWith|maxWithOrNull|sort|sortBy|sortWith|zip|transpose|toListing|step|sublist|sublistOrNull|replace|replaceOrNull|replaceRangeOrNull|intersect|difference|containsValue|put|remove|mapKeys|mapValues|toMapping)'
+
+  # #"(?:\#(reflect.Module(base).moduleClass.properties.keys.join("|")))"#
+  pklbase_module_properties: '(?:NaN|Infinity)'
+  # #"(?:\#(getProperties(reflect.Module(base)).join("|")))"#
+  pklbase_classes_properties: '(?:simpleName|output|version|since|message|replaceWith|names|subjects|language|prefix|suffix|minPklVersion|value|renderer|text|files|converters|extension|indent|omitNullProperties|useCustomStringDelimiters|before|after|mode|indentWidth|isStream|restrictCharset|uri|base64|md5|sha1|sha256|sha256Int|ns|us|ms|s|min|h|d|b|kb|mb|gb|tb|pb|kib|mib|gib|tib|pib|sign|abs|ceil|floor|isPositive|isFinite|isInfinite|isNaN|isNonZero|inv|isEven|isOdd|length|lastIndex|isEmpty|isBlank|isRegex|base64Decoded|chars|codePoints|pattern|groupCount|start|end|groups|isoString|unit|isBinaryUnit|isDecimalUnit|default|isDistinct|distinct|keys|first|second|key|firstOrNull|rest|restOrNull|last|lastOrNull|single|singleOrNull|minOrNull|max|maxOrNull|step|values|entries)'
+
+  # import "pkl:math"
+  # #"(?:\#(reflect.Module(math).moduleClass.properties.keys).join("|")))"#
+  pklmath_constant: '(?:minInt|minInt8|minInt16|minInt32|maxInt|maxInt8|maxInt16|maxInt32|maxUInt|maxUInt8|maxUInt16|maxUInt32|minFiniteFloat|maxFiniteFloat|minPositiveFloat|e|pi)'
+
+  # #"(?:\#(reflect.Module(math).moduleClass.methods.keys.join("|")))"#
+  pklmath_functions: '(?:exp|sqrt|cbrt|log|log2|log10|sin|cos|tan|asin|acos|atan|gcd|lcm|isPowerOfTwo|min|max)'
+
+  duration_unit: '(?:ns|us|ms|s|min|h|d)'
+  data_size_unit: '(?:b|kb|kib|mb|mib|gb|gib|tb|tib|pb|pib)'
 
 contexts:
   main:
@@ -37,11 +67,12 @@ contexts:
     - include: functions
     - include: lambda-function
     - include: class-declaration
-    - include: object-declaration
+    - include: instantiation
     - include: member-predicate
     - include: comments
     - include: strings
     - include: keyword
+    - include: base-built-ins
     - include: constants
     - include: super
     - include: operator
@@ -186,6 +217,9 @@ contexts:
     - match: '\b{{digits}}\b'
       scope: constant.numeric.integer.decimal.pkl
       push: after-expression
+    - match: '\bmath\.({{pklmath_constant}})\b'
+      captures:
+        1: constant.language.pkl
     - match: \b(true|false)\b
       scope: constant.language.boolean.pkl
     - match: \b(null)\b
@@ -209,6 +243,17 @@ contexts:
     - match: '\!|\&\&|\|\|'
       scope: keyword.operator.logical
 
+  base-built-ins:
+    - match: '{{pklbase_module_methods}}'
+      scope: support.function.pkl
+    - match: '\bmath\.({{pklmath_functions}})\b'
+      captures:
+        1: support.function.pkl
+
+  stdblib-built-ins:
+    - match: '{{pklbase_classes_methods}}'
+      scope: support.function.pkl
+
   keyword:
     - match: \b(protected|override|record|delete|match|case|vararg|const)\b
       scope: keyword.other.pkl
@@ -230,7 +275,6 @@ contexts:
   punctuation:
     - match: ';'
       scope: punctuation.terminator.pkl
-
 
   super:
     - match: \@({{base_ident}})
@@ -266,18 +310,31 @@ contexts:
   class-declaration:
     - match: '\b(open)\b'
       scope: storage.modifier.pkl
-    - match: '\b(class)\s+({{ident}})(?:\s*(extends)\s+({{ident}}))?'
+    - match: '\b(class)\s+({{ident}})'
       captures:
         1: storage.type.class.pkl keyword.declaration.class.pkl
         2: entity.name.class.pkl
-        3: storage.modifier.pkl
-        4: entity.name.class.pkl
-      push: class-block
+      push: [class-block, class-extends]
+
+  class-extends:
+    - match: '\s+(extends)\s+'
+      scope: storage.modifier.pkl
+      set:
+        - match: '\b{{pklbase_type_open}}'
+          scope: storage.type.class.pkl
+        - match: '\b(?:{{pklbase_type_external}}|{{pklbase_type_other}}|{{pklbase_type_abstract}}|{{pklbase_typealiases}})'
+          scope: invalid.illegal.pkl
+        - match: '\b{{ident}}\b'
+          scope: entity.name.class.pkl
+        - match: '(?=\S)'
+          pop: true
+    - match: '(?=\S)'
+      pop: true
 
   class-block:
     - match: '\{'
       scope: punctuation.section.class.begin.pkl
-      set:
+      push:
         - meta_content_scope: meta.class.pkl
         - match: '\}'
           scope: punctuation.section.class.end.pkl
@@ -286,32 +343,42 @@ contexts:
     - match: ''
       pop: true
 
-  object-declaration:
-    - match: '\b(new)\s+(?:(Dynamic)|({{ident}}))'
-      captures:
-        1: keyword.pkl
-        2: keyword.pkl
-        3: entity.name.class.pkl
+  instantiation:
+    - match: '\b(new)\s+'
+      scope: keyword.pkl
+      set:
+        - match: 'Mixin' # the only typealias that can be instantiated
+          scope: storage.type.class.pkl
+        - match: '(?:{{pklbase_type_other}}|{{pklbase_type_open}})'
+          scope: storage.type.class.pkl
+        - match: '(?:{{pklbase_type_external}}||{{pklbase_type_abstract}}|{{pklbase_typealiases}})'
+          scope: invalid.illegal.pkl
+        - match: '(?:{{ident}})'
+          scope: entity.name.class.pkl
+        - match: ''
+          pop: true
 
   type:
     - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping)\b
-      scope: storage.type.pkl
+      scope: storage.type.class.pkl
       push:
-        - match: '(?=<)'
+        - match: '(?=\s*<)'
           push: generic-angles
         - match: ''
           pop: true
-    - match: \b(U?Int(?:8|16|32)?|String|Uri|Char|Comparable|Boolean|Float|Number|Dynamic)\b
-      scope: storage.type.pkl
-    - match: \b(Any|nothing)\b
+    - match: '\b({{pklbase_types}})\b'
+      scope: storage.type.class.pkl
+    - match: '\b({{pklbase_typealiases}})\b'
+      scope: storage.type.enum.pkl
+    - match: \b(nothing)\b
       scope: storage.type.class.pkl
     - match: '\b{{ident}}\b'
       scope: entity.name.type.pkl
-    - match: '\|'
+    - match: '\s*\|\s*'
       scope: punctuation.separator.sequence.pkl
     - match: '\*'
       scope: punctuation.definition.annotation.pkl
-    - match: '(?=\()'
+    - match: '(?=\s*\()'
       push: type-constraint
     - match: ''
       pop: true
@@ -328,6 +395,7 @@ contexts:
   type-constraint-contents:
     - match: '(?=\))'
       pop: true
+    - include: stdblib-built-ins
     - include: main
 
   generic-angles:
@@ -454,7 +522,7 @@ contexts:
 
   asPattern:
     - match: '(as)\s+'
-      scope: keyword.pkl
+      scope: keyword.other.pkl
       push: type
 
   member-predicate:
@@ -468,9 +536,10 @@ contexts:
         - include: main
 
   after-expression:
-    - match: (\.)(?={{ident}})
+    - match: \s*(\.)\s*(?={{ident}})
       scope: punctuation.accessor.dot.pkl
       push:
+        - include: stdblib-built-ins
         - match: '{{duration_unit}}'
           scope: support.type.duration.pkl
           push: after-expression
@@ -481,7 +550,7 @@ contexts:
           pop: true
     - match: \s*(:)\s*
       scope: punctuation.separator.pkl
-      push: type
+      set: type
     - match: ''
       pop: true
 

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -102,7 +102,7 @@ contexts:
       pop: true
 
   string-interpolation:
-    - match: \(
+    - match: \\#*\(
       scope: punctuation.section.interpolation.begin.pkl
       push:
         - clear_scopes: 1
@@ -113,23 +113,21 @@ contexts:
         - include: main
 
   escape-char-0:
-    - match: '\\(?=\()'
-      scope: punctuation.section.interpolation.begin.pkl
+    - match: '(?=\\\()'
       push: string-interpolation
     - match: '\\'
       scope: constant.character.escape.pkl
       push: escaped-char
 
   escape-char-1:
-    - match: '\\#(?=\()'
-      scope: punctuation.section.interpolation.begin.pkl
+    - match: '(?=\\#\()'
       push: string-interpolation
     - match: '\\#'
       scope: constant.character.escape.pkl
       push: escaped-char
 
   escape-char-2:
-    - match: '\\##(?=\()'
+    - match: '(?=\\##\()'
       scope: punctuation.section.interpolation.begin.pkl
       push: string-interpolation
     - match: '\\##'
@@ -248,7 +246,7 @@ contexts:
   keyword:
     - match: \b(protected|override|record|delete|match|case|vararg|const)\b
       scope: keyword.other.pkl
-    - match: '\b(read\?|read\*|read|import\*)\b?'
+    - match: '\b(read\?|read\*|read|import\*)\s*'
       scope: keyword.import.pkl
     - match: \b(if|else|when)\b
       scope: keyword.control.conditional.pkl
@@ -275,7 +273,7 @@ contexts:
     - match: '`'
       scope: punctuation.section.quoted.begin.pkl
       push:
-        - meta_content_scope: meta.quoted.pkl variable.other.pkl
+        - meta_scope: meta.quoted.pkl variable.other.pkl
         - match: '`'
           scope: punctuation.section.quoted.end.pkl
           set: after-expression
@@ -568,10 +566,12 @@ contexts:
         - include: main
     - match: '\{'
       scope: punctuation.section.block.begin.pkl
-      push:
-        - meta_content_scope: meta.block.pkl
-        - match: '\}'
-          scope: punctuation.section.block.end.pkl
-          set: after-expression
-        - include: main
+      push: block
 
+
+  block:
+    - meta_content_scope: meta.block.pkl
+    - match: '\}'
+      scope: punctuation.section.block.end.pkl
+      set: after-expression
+    - include: main

--- a/syntaxes/Pkl.sublime-syntax
+++ b/syntaxes/Pkl.sublime-syntax
@@ -113,35 +113,50 @@ contexts:
         - include: main
 
   escape-char-0:
+    - match: '\\(?=\()'
+      scope: punctuation.section.interpolation.begin.pkl
+      push: string-interpolation
     - match: '\\'
       scope: constant.character.escape.pkl
-      push:
-        - include: string-interpolation
-        - include: escaped-char
+      push: escaped-char
 
   escape-char-1:
+    - match: '\\#(?=\()'
+      scope: punctuation.section.interpolation.begin.pkl
+      push: string-interpolation
     - match: '\\#'
       scope: constant.character.escape.pkl
-      push:
-        - include: string-interpolation
-        - include: escaped-char
+      push: escaped-char
 
   escape-char-2:
+    - match: '\\##(?=\()'
+      scope: punctuation.section.interpolation.begin.pkl
+      push: string-interpolation
     - match: '\\##'
       scope: constant.character.escape.pkl
-      push:
-        - include: string-interpolation
-        - include: escaped-char
+      push: escaped-char
 
   strings:
-    - include: string-multi-line-2
-    - include: string-single-line-2
-    - include: string-multi-line-1
-    - include: string-single-line-1
-    - include: string-multi-line-0
-    - include: string-single-line-0
+    - include: string-multi-line
+    - include: string-single-line
 
-  string-single-line-0:
+  string-single-line:
+    - match: '##"'
+      scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
+      push:
+        - meta_content_scope: string.quoted.double.2.pkl
+        - match: '"##'
+          scope: string.quoted.double.2.pkl punctuation.definition.string.end.2.pkl
+          set: after-expression
+        - include: escape-char-2
+    - match: '#"'
+      scope: string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
+      push:
+        - meta_content_scope: string.quoted.double.1.pkl
+        - match: '"#'
+          scope: string.quoted.double.1.pkl punctuation.definition.string.end.1.pkl
+          set: after-expression
+        - include: escape-char-1
     - match: '"'
       scope: string.quoted.double.0.pkl punctuation.definition.string.begin.0.pkl
       push:
@@ -151,47 +166,7 @@ contexts:
           set: after-expression
         - include: escape-char-0
 
-  string-single-line-1:
-    - match: '#"'
-      scope: string.quoted.double.1.pkl punctuation.definition.string.begin.1.pkl
-      push:
-        - meta_content_scope: string.quoted.double.1.pkl
-        - match: '"#'
-          scope: string.quoted.double.1.pkl punctuation.definition.string.end.1.pkl
-          set: after-expression
-        - include: escape-char-1
-
-  string-single-line-2:
-    - match: '##"'
-      scope: string.quoted.double.2.pkl punctuation.definition.string.begin.2.pkl
-      push:
-        - meta_content_scope: string.quoted.double.2.pkl
-        - match: '"##'
-          scope: string.quoted.double.2.pkl punctuation.definition.string.end.2.pkl
-          set: after-expression
-        - include: escape-char-2
-
-  string-multi-line-0:
-    - match: '(""")\s*?$' # content must start on a new line
-      scope: string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
-      push:
-        - meta_content_scope: string.quoted.triple.0.pkl
-        - match: '^\s*?(""")' # closing delim must start on a new line
-          scope: string.quoted.triple.0.pkl punctuation.definition.string.end.0.pkl
-          set: after-expression
-        - include: escape-char-0
-
-  string-multi-line-1:
-    - match: '(#""")\s*?$' # content must start on a new line
-      scope: string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
-      push:
-        - meta_content_scope: string.quoted.triple.1.pkl
-        - match: '^\s*?("""#)' # closing delim must start on a new line
-          scope: string.quoted.triple.1.pkl punctuation.definition.string.end.1.pkl
-          set: after-expression
-        - include: escape-char-1
-
-  string-multi-line-2:
+  string-multi-line:
     - match: '(##""")\s*?$' # content must start on a new line
       scope: string.quoted.triple.2.pkl punctuation.definition.string.begin.2.pkl
       push:
@@ -200,6 +175,22 @@ contexts:
           scope: string.quoted.triple.2.pkl punctuation.definition.string.end.2.pkl
           set: after-expression
         - include: escape-char-2
+    - match: '(#""")\s*?$' # content must start on a new line
+      scope: string.quoted.triple.1.pkl punctuation.definition.string.begin.1.pkl
+      push:
+        - meta_content_scope: string.quoted.triple.1.pkl
+        - match: '^\s*?("""#)' # closing delim must start on a new line
+          scope: string.quoted.triple.1.pkl punctuation.definition.string.end.1.pkl
+          set: after-expression
+        - include: escape-char-1
+    - match: '(""")\s*?$' # content must start on a new line
+      scope: string.quoted.triple.0.pkl punctuation.definition.string.begin.0.pkl
+      push:
+        - meta_content_scope: string.quoted.triple.0.pkl
+        - match: '^\s*?(""")' # closing delim must start on a new line
+          scope: string.quoted.triple.0.pkl punctuation.definition.string.end.0.pkl
+          set: after-expression
+        - include: escape-char-0
 
   constants:
     - match: '\b(?:{{digits}}?\.{{digits}}(?:[eE][+-]?{{digits}})?|{{digits}}[eE][+-]?{{digits}})\b'
@@ -284,7 +275,7 @@ contexts:
     - match: '`'
       scope: punctuation.section.quoted.begin.pkl
       push:
-        - meta_content_scope: meta.quoted.pkl
+        - meta_content_scope: meta.quoted.pkl variable.other.pkl
         - match: '`'
           scope: punctuation.section.quoted.end.pkl
           set: after-expression
@@ -319,14 +310,14 @@ contexts:
   class-extends:
     - match: '\s+(extends)\s+'
       scope: storage.modifier.pkl
-      set:
+      push:
         - match: '\b{{pklbase_type_open}}'
           scope: storage.type.class.pkl
         - match: '\b(?:{{pklbase_type_external}}|{{pklbase_type_other}}|{{pklbase_type_abstract}}|{{pklbase_typealiases}})'
           scope: invalid.illegal.pkl
         - match: '\b{{ident}}\b'
           scope: entity.name.class.pkl
-        - match: '(?=\S)'
+        - match: ''
           pop: true
     - match: '(?=\S)'
       pop: true
@@ -348,9 +339,9 @@ contexts:
       scope: keyword.pkl
       set:
         - match: 'Mixin' # the only typealias that can be instantiated
-          scope: storage.type.class.pkl
+          scope: support.type.pkl
         - match: '(?:{{pklbase_type_other}}|{{pklbase_type_open}})'
-          scope: storage.type.class.pkl
+          scope: support.type.pkl
         - match: '(?:{{pklbase_type_external}}||{{pklbase_type_abstract}}|{{pklbase_typealiases}})'
           scope: invalid.illegal.pkl
         - match: '(?:{{ident}})'
@@ -360,16 +351,16 @@ contexts:
 
   type:
     - match: \b(Pair|Collection|List|Set|Map|Listing|Mapping)\b
-      scope: storage.type.class.pkl
+      scope: support.type.pkl
       push:
         - match: '(?=\s*<)'
           push: generic-angles
         - match: ''
           pop: true
     - match: '\b({{pklbase_types}})\b'
-      scope: storage.type.class.pkl
+      scope: support.type.pkl
     - match: '\b({{pklbase_typealiases}})\b'
-      scope: storage.type.enum.pkl
+      scope: support.type.enum.pkl
     - match: \b(nothing)\b
       scope: storage.type.class.pkl
     - match: '\b{{ident}}\b'
@@ -379,7 +370,7 @@ contexts:
     - match: '(?=")'
       push:
         - meta_content_scope: meta.type.string-literal.pkl
-        - include: string-single-line-0
+        - include: string-single-line
         - match: ''
           pop: true
     - match: '\*'


### PR DESCRIPTION
Hello again,

Another PR with a big improvment and some minor ones:

Big one: 
- the syntax now recognises all built-in classes, typealiases, and methods and offers some  rough logic i.e.: you can't extend a non `open` class, so writing `class Bird extends Int { ... } ` will mark `Int` as invalid since `Int` is not `open`.
Or also trying to instantiate and `extern` class will also lead to complaints `a = new String {...} //illegal`.
- Added support to constants and methods from the `math` module
- All built-in classes and types are scoped as `storage.type.class.pkl` to differentiate them from custom identifiers that are scoped as `entity.name.class.pkl`.
 - typealiases scoped as `storage.type.enum.pkl`
- built-in methods are scoped as `support.function.pkl`


One big thing missing, since I am not completely sure how to proceed, is trying to scope built-in classes properties, for example: the property of `Int`s `isEven`: `3.isEven` or the property `output` of the module class? should these be scoped as "special" or just leave them unscoped?

Also, I am really not sure how to scope the built-in types and classes, as mentioned I have used `storage.type.class.pkl` so far, but ideally and following the indications of the scope naming page as well as looking at other languages, they could potentially be scoped as `support.type.pkl` instead.
I am more inclined to use `support.type.pkl` since it is more in line with other syntaxes, the scope naming convention and the fact that we are using `support.function.pkl` for the methods of the base module

Other minor changes:
- better function and lambdas parsing
- better typealias parsing
- addressed #3, sorry my syntax doesn't highlight them so didn't realise! now they are scoped as `meta.{property,object,entry,name}.pkl` where `name` is the catchall value.
- some fixes overall and added tests in the syntax file